### PR TITLE
Rename DocumentRepository -> DocumentDao

### DIFF
--- a/application/androidApp/src/androidMain/kotlin/io/writeopia/navigation/NavigationActivity.kt
+++ b/application/androidApp/src/androidMain/kotlin/io/writeopia/navigation/NavigationActivity.kt
@@ -23,8 +23,7 @@ import io.writeopia.editor.di.EditorInjector
 import io.writeopia.editor.navigation.editorNavigation
 import io.writeopia.note_menu.di.NotesMenuInjection
 import io.writeopia.note_menu.navigation.notesMenuNavigation
-import io.writeopia.persistence.WriteopiaApplicationDatabase
-import io.writeopia.persistence.injection.RepositoriesInjection
+import io.writeopia.persistence.injection.DaoInjection
 import io.writeopia.sdk.network.injector.ApiInjector
 import io.writeopia.theme.ApplicationComposeTheme
 import io.writeopia.utils_module.Destinations
@@ -59,11 +58,11 @@ fun NavigationGraph(
     val apiInjector =
         ApiInjector(apiLogger = AndroidLogger, bearerTokenHandler = AmplifyTokenHandler)
     val authCoreInjection = AuthCoreInjection(sharedPreferences)
-    val repositoriesInjection = RepositoriesInjection(application)
-    val authInjection = AuthInjection(authCoreInjection, apiInjector, repositoriesInjection)
-    val editorInjector = EditorInjector(authCoreInjection, repositoriesInjection)
+    val daoInjection = DaoInjection(application)
+    val authInjection = AuthInjection(authCoreInjection, apiInjector, daoInjection)
+    val editorInjector = EditorInjector(authCoreInjection, daoInjection)
     val notesMenuInjection =
-        NotesMenuInjection(sharedPreferences, authCoreInjection.provideAccountManager(), repositoriesInjection)
+        NotesMenuInjection(sharedPreferences, authCoreInjection.provideAccountManager(), daoInjection)
 
     ApplicationComposeTheme {
         NavHost(navController = navController, startDestination = startDestination) {

--- a/application/features/auth/src/main/java/io/writeopia/auth/di/AuthInjection.kt
+++ b/application/features/auth/src/main/java/io/writeopia/auth/di/AuthInjection.kt
@@ -9,25 +9,25 @@ import io.writeopia.auth.intronotes.IntroNotesUseCase
 import io.writeopia.auth.login.LoginViewModel
 import io.writeopia.auth.menu.AuthMenuViewModel
 import io.writeopia.auth.register.RegisterViewModel
-import io.writeopia.persistence.injection.RepositoriesInjection
-import io.writeopia.sdk.manager.DocumentRepository
+import io.writeopia.persistence.injection.DaoInjection
+import io.writeopia.sdk.manager.DocumentDao
 import io.writeopia.sdk.network.injector.ApiInjector
 import io.writeopia.sdk.network.notes.NotesApi
 
 class AuthInjection(
     private val authCoreInjection: AuthCoreInjection,
     private val apiInjector: ApiInjector,
-    private val repositoriesInjection: RepositoriesInjection
+    private val daoInjection: DaoInjection
 ) {
 
-    private fun provideDocumentRepository(): DocumentRepository = repositoriesInjection.provideDocumentRepository()
+    private fun provideDocumentRepository(): DocumentDao = daoInjection.provideDocumentDao()
 
     private fun provideIntroNotesUseCase(
-        documentRepository: DocumentRepository = provideDocumentRepository(),
+        documentDao: DocumentDao = provideDocumentRepository(),
         notesApi: NotesApi = apiInjector.notesApi()
     ): IntroNotesUseCase =
         IntroNotesUseCase(
-            documentRepository = documentRepository,
+            documentDao = documentDao,
             notesApi = notesApi
         )
 

--- a/application/features/auth/src/main/java/io/writeopia/auth/intronotes/IntroNotesUseCase.kt
+++ b/application/features/auth/src/main/java/io/writeopia/auth/intronotes/IntroNotesUseCase.kt
@@ -1,16 +1,16 @@
 package io.writeopia.auth.intronotes
 
-import io.writeopia.sdk.manager.DocumentRepository
+import io.writeopia.sdk.manager.DocumentDao
 import io.writeopia.sdk.network.notes.NotesApi
 
 internal class IntroNotesUseCase(
-    private val documentRepository: DocumentRepository,
+    private val documentDao: DocumentDao,
     private val notesApi: NotesApi
 ) {
 
     suspend fun addIntroNotes() {
         notesApi.introNotes().forEach { document ->
-            documentRepository.saveDocument(document)
+            documentDao.saveDocument(document)
         }
     }
 }

--- a/application/features/editor/src/main/java/io/writeopia/editor/NoteEditorViewModel.kt
+++ b/application/features/editor/src/main/java/io/writeopia/editor/NoteEditorViewModel.kt
@@ -10,14 +10,13 @@ import io.writeopia.sdk.backstack.BackstackInform
 import io.writeopia.sdk.export.DocumentToMarkdown
 import io.writeopia.sdk.filter.DocumentFilter
 import io.writeopia.sdk.filter.DocumentFilterObject
-import io.writeopia.sdk.manager.DocumentRepository
+import io.writeopia.sdk.manager.DocumentDao
 import io.writeopia.sdk.manager.WriteopiaManager
 import io.writeopia.sdk.model.action.Action
 import io.writeopia.sdk.model.story.DrawState
 import io.writeopia.sdk.model.story.StoryState
 import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.models.story.Decoration
-import io.writeopia.sdk.persistence.core.tracker.OnUpdateDocumentTracker
 import io.writeopia.sdk.serialization.extensions.toApi
 import io.writeopia.sdk.serialization.json.writeopiaJson
 import io.writeopia.sdk.serialization.request.wrapInRequest
@@ -37,7 +36,7 @@ import kotlinx.serialization.json.Json
 
 internal class NoteEditorViewModel(
     val writeopiaManager: WriteopiaManager,
-    private val documentRepository: DocumentRepository,
+    private val documentDao: DocumentDao,
     private val documentFilter: DocumentFilter = DocumentFilterObject,
 ) : ViewModel(),
     BackstackInform by writeopiaManager,
@@ -110,10 +109,10 @@ internal class NoteEditorViewModel(
 
         viewModelScope.launch {
             writeopiaManager.currentDocument.stateIn(this).value?.let { document ->
-                documentRepository.saveDocument(document)
+                documentDao.saveDocument(document)
                 writeopiaManager.saveOnStoryChanges(
                     io.writeopia.sdk.persistence.core.tracker.OnUpdateDocumentTracker(
-                        documentRepository
+                        documentDao
                     )
                 )
             }
@@ -124,13 +123,13 @@ internal class NoteEditorViewModel(
         if (writeopiaManager.isInitialized()) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            val document = documentRepository.loadDocumentById(documentId)
+            val document = documentDao.loadDocumentById(documentId)
 
             if (document != null) {
                 writeopiaManager.initDocument(document)
                 writeopiaManager.saveOnStoryChanges(
                     io.writeopia.sdk.persistence.core.tracker.OnUpdateDocumentTracker(
-                        documentRepository
+                        documentDao
                     )
                 )
             }
@@ -142,7 +141,7 @@ internal class NoteEditorViewModel(
             val document = writeopiaManager.currentDocument.stateIn(this).value
 
             if (document != null && story.value.stories.noContent()) {
-                documentRepository.deleteDocument(document)
+                documentDao.deleteDocument(document)
             }
 
             withContext(Dispatchers.Main) {

--- a/application/features/editor/src/main/java/io/writeopia/editor/di/EditorInjector.kt
+++ b/application/features/editor/src/main/java/io/writeopia/editor/di/EditorInjector.kt
@@ -5,18 +5,18 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import io.writeopia.auth.core.di.AuthCoreInjection
 import io.writeopia.auth.core.manager.AuthManager
 import io.writeopia.editor.NoteEditorViewModel
-import io.writeopia.persistence.injection.RepositoriesInjection
-import io.writeopia.sdk.manager.DocumentRepository
+import io.writeopia.persistence.injection.DaoInjection
+import io.writeopia.sdk.manager.DocumentDao
 import io.writeopia.sdk.manager.WriteopiaManager
 import kotlinx.coroutines.Dispatchers
 
 class EditorInjector(
     private val authCoreInjection: AuthCoreInjection,
-    private val repositoriesInjection: RepositoriesInjection
+    private val daoInjection: DaoInjection
 ) {
 
-    private fun provideDocumentRepository(): DocumentRepository =
-        repositoriesInjection.provideDocumentRepository()
+    private fun provideDocumentRepository(): DocumentDao =
+        daoInjection.provideDocumentDao()
 
     private fun provideWriteopiaManager(
         authManager: AuthManager = authCoreInjection.provideAccountManager()
@@ -27,11 +27,11 @@ class EditorInjector(
 
     @Composable
     internal fun provideNoteDetailsViewModel(
-        documentRepository: DocumentRepository = provideDocumentRepository(),
+        documentDao: DocumentDao = provideDocumentRepository(),
         writeopiaManager: WriteopiaManager = provideWriteopiaManager()
     ): NoteEditorViewModel {
         return viewModel(initializer = {
-            NoteEditorViewModel(writeopiaManager, documentRepository)
+            NoteEditorViewModel(writeopiaManager, documentDao)
         })
     }
 }

--- a/application/features/note_menu/src/main/java/io/writeopia/note_menu/data/usecase/NotesUseCase.kt
+++ b/application/features/note_menu/src/main/java/io/writeopia/note_menu/data/usecase/NotesUseCase.kt
@@ -1,6 +1,6 @@
 package io.writeopia.note_menu.data.usecase
 
-import io.writeopia.sdk.manager.DocumentRepository
+import io.writeopia.sdk.manager.DocumentDao
 import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.models.id.GenerateId
 
@@ -9,17 +9,17 @@ import io.writeopia.sdk.models.id.GenerateId
  * consideration the configuration desired in the app.
  */
 internal class NotesUseCase(
-    private val documentRepository: DocumentRepository,
+    private val documentDao: DocumentDao,
     private val notesConfig: NotesConfigurationRepository
 ) {
 
     suspend fun loadDocumentsForUser(userId: String): List<Document> =
         notesConfig.getOrderPreference()
-            ?.let { orderBy -> documentRepository.loadDocumentsForUser(orderBy, userId) }!!
+            ?.let { orderBy -> documentDao.loadDocumentsForUser(orderBy, userId) }!!
 
     suspend fun duplicateDocuments(ids: List<String>) {
         notesConfig.getOrderPreference()?.let { orderBy ->
-            documentRepository.loadDocumentsById(ids, orderBy)
+            documentDao.loadDocumentsById(ids, orderBy)
         }?.let { documents ->
             documents.map { document ->
                 document.copy(
@@ -30,12 +30,12 @@ internal class NotesUseCase(
             }
         }?.let { newDocuments ->
             newDocuments.forEach { document ->
-                documentRepository.saveDocument(document)
+                documentDao.saveDocument(document)
             }
         }
     }
 
     suspend fun deleteNotes(ids: Set<String>) {
-        documentRepository.deleteDocumentById(ids)
+        documentDao.deleteDocumentById(ids)
     }
 }

--- a/application/features/note_menu/src/main/java/io/writeopia/note_menu/di/NotesMenunjection.kt
+++ b/application/features/note_menu/src/main/java/io/writeopia/note_menu/di/NotesMenunjection.kt
@@ -3,30 +3,30 @@ package io.writeopia.note_menu.di
 import android.content.SharedPreferences
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.writeopia.sdk.manager.DocumentRepository
+import io.writeopia.sdk.manager.DocumentDao
 import io.writeopia.auth.core.manager.AuthManager
 import io.writeopia.note_menu.data.usecase.NotesConfigurationRepository
 import io.writeopia.note_menu.data.usecase.NotesUseCase
 import io.writeopia.note_menu.viewmodel.ChooseNoteViewModel
-import io.writeopia.persistence.injection.RepositoriesInjection
+import io.writeopia.persistence.injection.DaoInjection
 
 class NotesMenuInjection(
     private val sharedPreferences: SharedPreferences,
     private val authManager: AuthManager,
-    private val repositoriesInjection: RepositoriesInjection
+    private val daoInjection: DaoInjection
 ) {
 
-    private fun provideDocumentRepository(): DocumentRepository = repositoriesInjection.provideDocumentRepository()
+    private fun provideDocumentRepository(): DocumentDao = daoInjection.provideDocumentDao()
 
     private fun provideNotesConfigurationRepository(): NotesConfigurationRepository =
         NotesConfigurationRepository(sharedPreferences)
 
     private fun provideNotesUseCase(
-        documentRepository: DocumentRepository = provideDocumentRepository(),
+        documentDao: DocumentDao = provideDocumentRepository(),
         notesConfigurationRepository: NotesConfigurationRepository =
             provideNotesConfigurationRepository()
     ): NotesUseCase {
-        return NotesUseCase(documentRepository, notesConfigurationRepository)
+        return NotesUseCase(documentDao, notesConfigurationRepository)
     }
 
     @Composable

--- a/application/persistence/src/androidTest/java/io/writeopia/persistence/DocumentDaoTest.kt
+++ b/application/persistence/src/androidTest/java/io/writeopia/persistence/DocumentDaoTest.kt
@@ -8,11 +8,9 @@ import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.models.id.GenerateId
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
-import io.writeopia.sdk.persistence.dao.DocumentDao
 import io.writeopia.sdk.persistence.dao.StoryUnitDao
 import io.writeopia.sdk.persistence.parse.toEntity
 import io.writeopia.sdk.persistence.parse.toModel
-import io.writeopia.sdk.persistence.repository.DocumentRepositoryImpl
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -22,12 +20,12 @@ import org.junit.runner.RunWith
 import java.time.Instant
 
 @RunWith(AndroidJUnit4::class)
-class DocumentRepositoryTest {
+class DocumentDaoTest {
 
     private lateinit var database: WriteopiaApplicationDatabase
-    private lateinit var documentDao: DocumentDao
+    private lateinit var documentDao: io.writeopia.sdk.persistence.dao.DocumentDao
     private lateinit var storyUnitDao: StoryUnitDao
-    private lateinit var documentRepository: DocumentRepositoryImpl
+    private lateinit var documentRepository: io.writeopia.sdk.persistence.repository.DocumentDao
 
     @Before
     fun createDb() {
@@ -40,7 +38,7 @@ class DocumentRepositoryTest {
         documentDao = database.documentDao()
         storyUnitDao = database.storyUnitDao()
 
-        documentRepository = DocumentRepositoryImpl(documentDao, storyUnitDao)
+        documentRepository = io.writeopia.sdk.persistence.repository.DocumentDao(documentDao, storyUnitDao)
     }
 
     @After

--- a/application/persistence/src/main/java/io/writeopia/persistence/injection/DaoInjection.kt
+++ b/application/persistence/src/main/java/io/writeopia/persistence/injection/DaoInjection.kt
@@ -2,15 +2,15 @@ package io.writeopia.persistence.injection
 
 import android.app.Application
 import io.writeopia.persistence.WriteopiaApplicationDatabase
-import io.writeopia.sdk.manager.DocumentRepository
-import io.writeopia.sdk.persistence.repository.DocumentRepositoryImpl
+import io.writeopia.sdk.manager.DocumentDao
+import io.writeopia.sdk.persistence.repository.DocumentDao
 
-class RepositoriesInjection(application: Application) {
+class DaoInjection(application: Application) {
 
     private val database: WriteopiaApplicationDatabase = WriteopiaApplicationDatabase.database(application)
 
-    fun provideDocumentRepository(): DocumentRepository =
-        DocumentRepositoryImpl(
+    fun provideDocumentDao(): io.writeopia.sdk.manager.DocumentDao =
+        DocumentDao(
             database.documentDao(),
             database.storyUnitDao()
         )

--- a/plugins/writeopia_persistence_room/src/main/java/io/writeopia/sdk/persistence/repository/DocumentDao.kt
+++ b/plugins/writeopia_persistence_room/src/main/java/io/writeopia/sdk/persistence/repository/DocumentDao.kt
@@ -1,19 +1,17 @@
 package io.writeopia.sdk.persistence.repository
 
-import io.writeopia.sdk.manager.DocumentRepository
 import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.models.story.StoryStep
-import io.writeopia.sdk.persistence.dao.DocumentDao
 import io.writeopia.sdk.persistence.dao.StoryUnitDao
 import io.writeopia.sdk.persistence.entity.document.DocumentEntity
 import io.writeopia.sdk.persistence.entity.story.StoryStepEntity
 import io.writeopia.sdk.persistence.parse.toEntity
 import io.writeopia.sdk.persistence.parse.toModel
 
-class DocumentRepositoryImpl(
+class DocumentDao(
     private val documentDao: DocumentDao,
     private val storyUnitDao: StoryUnitDao
-) : DocumentRepository {
+) : io.writeopia.sdk.manager.DocumentDao {
 
     override suspend fun loadDocumentsForUser(orderBy: String, userId: String): List<Document> =
         documentDao.loadDocumentsWithContentForUser(orderBy, userId)

--- a/writeopia/src/commonMain/kotlin/io/writeopia/sdk/manager/DocumentDao.kt
+++ b/writeopia/src/commonMain/kotlin/io/writeopia/sdk/manager/DocumentDao.kt
@@ -8,7 +8,7 @@ import io.writeopia.sdk.models.story.StoryStep
  * The implementations of this interface shouldn't control order (sorting) or oder configurations,
  * those need to be passed as parameters.
  */
-interface DocumentRepository : DocumentUpdate {
+interface DocumentDao : DocumentUpdate {
 
     suspend fun loadDocumentsForUser(orderBy: String, userId: String): List<Document>
 


### PR DESCRIPTION
DocumentRepository should be an Data Access Object because it is abstracting away only the database, not all sources of data.