### PR TITLE
Moving cursor correctly and bulk delete in desktop

### DIFF
--- a/application/desktopApp/src/jvmMain/kotlin/io/writeopia/desktop/MainDesktop.kt
+++ b/application/desktopApp/src/jvmMain/kotlin/io/writeopia/desktop/MainDesktop.kt
@@ -94,6 +94,16 @@ fun main() = application {
                     true
                 }
 
+                isDeleteEvent(keyEvent) -> {
+                    coroutineScope.launch(Dispatchers.IO) {
+                        keyboardEventFlow.tryEmit(KeyboardEvent.DELETE)
+                        delay(100)
+                        keyboardEventFlow.tryEmit(KeyboardEvent.IDLE)
+                    }
+
+                    false
+                }
+
                 else -> false
             }
         }
@@ -152,6 +162,10 @@ private fun isSelectionKeyEventStop(keyEvent: AndroidKeyEvent) =
 
 private fun isMoveDownEvent(keyEvent: AndroidKeyEvent) =
     keyEvent.awtEventOrNull?.keyCode == KeyEvent.VK_DOWN
+
+private fun isDeleteEvent(keyEvent: AndroidKeyEvent) =
+    keyEvent.awtEventOrNull?.keyCode == KeyEvent.VK_DELETE ||
+        keyEvent.awtEventOrNull?.keyCode == KeyEvent.VK_BACK_SPACE
 
 private fun isMoveUpEvent(keyEvent: AndroidKeyEvent) =
     keyEvent.awtEventOrNull?.keyCode == KeyEvent.VK_UP

--- a/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/ui/TextEditor.kt
+++ b/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/ui/TextEditor.kt
@@ -46,9 +46,6 @@ internal fun TextEditor(
             defaultBorder = clipShape,
             onHeaderClick = noteEditorViewModel::onHeaderClick,
             editable = true,
-            textCommandHandler = TextCommandHandler.defaultCommands(
-                noteEditorViewModel.writeopiaManager
-            ),
             groupsBackgroundColor = Color.Transparent,
         ),
         storyState = storyState,

--- a/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/ui/TextEditor.kt
+++ b/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/ui/TextEditor.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import io.writeopia.editor.viewmodel.NoteEditorViewModel
 import io.writeopia.ui.WriteopiaEditor
 import io.writeopia.ui.drawer.factory.DrawersFactory
-import io.writeopia.ui.edition.TextCommandHandler
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable

--- a/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/viewmodel/NoteEditorKmpViewModel.kt
+++ b/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/viewmodel/NoteEditorKmpViewModel.kt
@@ -6,7 +6,6 @@ import io.writeopia.sdk.export.DocumentToMarkdown
 import io.writeopia.sdk.filter.DocumentFilter
 import io.writeopia.sdk.filter.DocumentFilterObject
 import io.writeopia.sdk.model.action.Action
-import io.writeopia.sdk.model.story.DrawState
 import io.writeopia.sdk.model.story.StoryState
 import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.persistence.core.repository.DocumentRepository
@@ -19,6 +18,7 @@ import io.writeopia.sdk.utils.extensions.noContent
 import io.writeopia.ui.backstack.BackstackHandler
 import io.writeopia.ui.backstack.BackstackInform
 import io.writeopia.ui.manager.WriteopiaStateManager
+import io.writeopia.ui.model.DrawState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch

--- a/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/viewmodel/NoteEditorViewModel.kt
+++ b/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/viewmodel/NoteEditorViewModel.kt
@@ -1,10 +1,10 @@
 package io.writeopia.editor.viewmodel
 
 import io.writeopia.editor.model.EditState
-import io.writeopia.sdk.model.story.DrawState
 import io.writeopia.ui.backstack.BackstackHandler
 import io.writeopia.ui.backstack.BackstackInform
 import io.writeopia.ui.manager.WriteopiaStateManager
+import io.writeopia.ui.model.DrawState
 import kotlinx.coroutines.flow.StateFlow
 
 interface NoteEditorViewModel : BackstackInform, BackstackHandler {

--- a/application/features/note_menu/src/androidInstrumentedTest/kotlin/io/writeopia/note_menu/data/usecase/NotesUseCaseIntegrationTest.kt
+++ b/application/features/note_menu/src/androidInstrumentedTest/kotlin/io/writeopia/note_menu/data/usecase/NotesUseCaseIntegrationTest.kt
@@ -3,6 +3,7 @@ package io.writeopia.note_menu.data.usecase
 import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import io.writeopia.common.utils.DISCONNECTED_USER_ID
 import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.note_menu.data.repository.ConfigurationRepository
 import io.writeopia.note_menu.data.repository.ConfigurationRoomRepository
@@ -11,7 +12,6 @@ import io.writeopia.persistence.room.WriteopiaApplicationDatabase
 import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.persistence.core.repository.DocumentRepository
 import io.writeopia.sdk.persistence.dao.room.RoomDocumentRepository
-import io.writeopia.common.utils.DISCONNECTED_USER_ID
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock

--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/data/repository/ConfigurationRoomRepository.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/data/repository/ConfigurationRoomRepository.kt
@@ -65,7 +65,6 @@ internal class ConfigurationRoomRepository(
             ?: OrderBy.CREATE.type.toEntityField()
 
     override suspend fun saveWorkspacePath(path: String, userId: String) {
-
     }
 
     override suspend fun loadWorkspacePath(userId: String): String? = null

--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/data/repository/RoomFolderRepository.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/data/repository/RoomFolderRepository.kt
@@ -87,7 +87,6 @@ class RoomFolderRepository(private val folderRoomDao: FolderRoomDao) : FolderRep
         }
     }
 
-
     override suspend fun stopListeningForFoldersByParentId(parentId: String) {
         SelectedIds.ids.remove(parentId)
     }

--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/di/NotesInjector.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/di/NotesInjector.kt
@@ -3,7 +3,6 @@ package io.writeopia.note_menu.di
 import io.writeopia.note_menu.data.repository.ConfigurationRepository
 import io.writeopia.note_menu.data.repository.ConfigurationRoomRepository
 import io.writeopia.note_menu.data.repository.FolderRepository
-import io.writeopia.note_menu.data.repository.InMemoryFolderRepository
 import io.writeopia.note_menu.data.repository.RoomFolderRepository
 import io.writeopia.persistence.room.injection.AppRoomDaosInjection
 
@@ -21,4 +20,3 @@ actual class NotesInjector(private val appRoomDaosInjection: AppRoomDaosInjectio
     actual fun provideFoldersRepository(): FolderRepository =
         RoomFolderRepository(appRoomDaosInjection.provideFolderDao())
 }
-

--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/ui/screen/menu/ChooseNoteScreen.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/ui/screen/menu/ChooseNoteScreen.kt
@@ -110,9 +110,8 @@ internal fun ChooseNoteScreen(
     }
 }
 
-
 @OptIn(ExperimentalMaterial3Api::class)
-//@Preview(backgroundColor = 0xFF000000)
+// @Preview(backgroundColor = 0xFF000000)
 @Composable
 private fun TopBar(
     titleState: StateFlow<UserState<String>> = MutableStateFlow(UserState.ConnectedUser("Title")),
@@ -127,7 +126,6 @@ private fun TopBar(
                 modifier = Modifier.clickable(onClick = accountClick),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-
                 val userIcon = Icons.Outlined.Person
 
                 val fallbackPainter = rememberVectorPainter(
@@ -232,7 +230,7 @@ private fun Content(
         loadNote = loadNote,
         selectionListener = selectionListener,
         folderClick = {},
-        moveRequest = {_, _ -> },
+        moveRequest = { _, _ -> },
         modifier = Modifier
             .padding(paddingValues)
             .fillMaxSize()

--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/ui/screen/menu/NotesMenuScreen.android.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/ui/screen/menu/NotesMenuScreen.android.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import io.writeopia.model.ColorThemeOption
-import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.note_menu.data.model.NotesNavigation
 import io.writeopia.note_menu.ui.dto.MenuItemUi
 import io.writeopia.note_menu.viewmodel.ChooseNoteViewModel

--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/viewmodel/UiConfigurationAndroidViewModel.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/note_menu/viewmodel/UiConfigurationAndroidViewModel.kt
@@ -7,7 +7,7 @@ import io.writeopia.viewmodel.UiConfigurationViewModel
 
 class UiConfigurationAndroidViewModel(
     private val uiConfigurationKmpViewModel: UiConfigurationKmpViewModel
-) : UiConfigurationViewModel by uiConfigurationKmpViewModel, ViewModel(){
+) : UiConfigurationViewModel by uiConfigurationKmpViewModel, ViewModel() {
 
     init {
         uiConfigurationKmpViewModel.initCoroutine(viewModelScope)

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/edit_folder/EditFolderViewModel.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/edit_folder/EditFolderViewModel.kt
@@ -5,20 +5,17 @@ import androidx.compose.ui.graphics.toArgb
 import io.writeopia.common.utils.KmpViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class EditFolderViewModel: KmpViewModel() {
+class EditFolderViewModel : KmpViewModel() {
 
     private val _nameState = MutableStateFlow("")
     private val _colorState = MutableStateFlow(Color.White.toArgb())
 
     fun createFolder() {
-
     }
 
     fun updateFolderName(name: String) {
-
     }
 
     fun updateColor() {
-
     }
 }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/model/NotesArrangement.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/model/NotesArrangement.kt
@@ -5,7 +5,10 @@ package io.writeopia.note_menu.data.model
  * changing the way notes present themselves in the menu
  */
 enum class NotesArrangement(val type: String) {
-    LIST("list"), GRID("grid"), STAGGERED_GRID("staggered_grid");
+    LIST("list"),
+    GRID("grid"),
+    STAGGERED_GRID("staggered_grid");
+
     companion object {
         fun fromString(string: String): NotesArrangement =
             entries.firstOrNull { notesArrangement ->

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/model/NotesNavigation.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/model/NotesNavigation.kt
@@ -20,12 +20,12 @@ sealed class NotesNavigation(val navigationType: NotesNavigationType, val id: St
 }
 
 enum class NotesNavigationType(val type: String) {
-    FAVORITES("favorites"), ROOT("root"), FOLDER("folder");
+    FAVORITES("favorites"),
+    ROOT("root"),
+    FOLDER("folder");
 
     companion object {
         fun fromType(type: String) = entries.firstOrNull { it.type == type }
             ?: throw IllegalArgumentException("Could not find type: $type")
     }
 }
-
-

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/repository/InMemoryConfigurationRepository.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/repository/InMemoryConfigurationRepository.kt
@@ -5,7 +5,7 @@ import io.writeopia.sdk.persistence.core.sorting.OrderBy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
-class InMemoryConfigurationRepository private constructor(): ConfigurationRepository {
+class InMemoryConfigurationRepository private constructor() : ConfigurationRepository {
 
     private val arrangementPrefs = mutableMapOf<String, String>()
     private val sortPrefs = mutableMapOf<String, String>()

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/repository/InMemoryFolderRepository.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/repository/InMemoryFolderRepository.kt
@@ -80,8 +80,5 @@ class InMemoryFolderRepository : FolderRepository {
     }
 
     override suspend fun stopListeningForFoldersByParentId(parentId: String) {
-
     }
-
-
 }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/usecase/NotesUseCase.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/data/usecase/NotesUseCase.kt
@@ -1,5 +1,6 @@
 package io.writeopia.note_menu.data.usecase
 
+import io.writeopia.common.utils.collections.merge
 import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.note_menu.data.model.NotesNavigation
 import io.writeopia.note_menu.data.repository.ConfigurationRepository
@@ -11,7 +12,6 @@ import io.writeopia.sdk.models.document.MenuItem
 import io.writeopia.sdk.models.id.GenerateId
 import io.writeopia.sdk.persistence.core.repository.DocumentRepository
 import io.writeopia.sdk.persistence.core.sorting.OrderBy
-import io.writeopia.common.utils.collections.merge
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -199,7 +199,7 @@ class NotesUseCase private constructor(
         folderRepository.getFolderByParentId(parentId)
 
     private suspend fun duplicateFolder(folder: Folder): Folder {
-        //Todo: É necessário mudar o parent id da pasta também
+        // Todo: É necessário mudar o parent id da pasta também
         val newFolder = folder.copy(id = GenerateId.generate())
 
         return run {
@@ -254,5 +254,5 @@ private fun Document.duplicateWithNewIds(): Document =
         id = GenerateId.generate(),
         content = this.content.mapValues { (_, storyStep) ->
             storyStep.copy(id = GenerateId.generate())
-        })
-
+        }
+    )

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/di/NotesMenuInjection.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/di/NotesMenuInjection.kt
@@ -12,5 +12,4 @@ interface NotesMenuInjection {
         coroutineScope: CoroutineScope?,
         notesNavigation: NotesNavigation
     ): ChooseNoteViewModel
-
 }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/di/NotesMenuKmpInjection.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/di/NotesMenuKmpInjection.kt
@@ -10,7 +10,6 @@ import io.writeopia.note_menu.data.usecase.NotesUseCase
 import io.writeopia.note_menu.viewmodel.ChooseNoteKmpViewModel
 import io.writeopia.note_menu.viewmodel.ChooseNoteViewModel
 import io.writeopia.note_menu.viewmodel.FolderStateController
-import io.writeopia.repository.UiConfigurationRepository
 import io.writeopia.sdk.persistence.core.di.RepositoryInjector
 import io.writeopia.sdk.persistence.core.repository.DocumentRepository
 import kotlinx.coroutines.CoroutineScope
@@ -69,4 +68,3 @@ class NotesMenuKmpInjection(
             }
         }
 }
-

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/extensions/DocumentExtensions.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/extensions/DocumentExtensions.kt
@@ -42,4 +42,3 @@ fun MenuItem.toUiCard(
 
         else -> throw IllegalArgumentException("MenuItemUi could not me created")
     }
-

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/navigation/NotesMenuNavigation.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/navigation/NotesMenuNavigation.kt
@@ -9,13 +9,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import io.writeopia.common.utils.Destinations
 import io.writeopia.model.ColorThemeOption
 import io.writeopia.note_menu.data.model.NotesNavigation
 import io.writeopia.note_menu.data.model.NotesNavigationType
 import io.writeopia.note_menu.di.NotesMenuInjection
 import io.writeopia.note_menu.ui.screen.menu.NotesMenuScreen
 import io.writeopia.note_menu.viewmodel.ChooseNoteViewModel
-import io.writeopia.common.utils.Destinations
 import kotlinx.coroutines.CoroutineScope
 
 const val NAVIGATION_TYPE = "type"
@@ -81,7 +81,6 @@ fun NavGraphBuilder.notesMenuNavigation(
                         "${Destinations.CHOOSE_NOTE.id}/${navigation.navigationType.type}/path",
                     )
                 }
-
             },
             addFolder = chooseNoteViewModel::addFolder,
             editFolder = chooseNoteViewModel::editFolder,

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/dto/DocumentUi.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/dto/DocumentUi.kt
@@ -1,9 +1,9 @@
 package io.writeopia.note_menu.ui.dto
 
+import io.writeopia.common.utils.Node
 import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.utils.Traversable
-import io.writeopia.common.utils.Node
 
 sealed interface MenuItemUi : Node, Traversable {
     val documentId: String

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/DesktopNotesMenu.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/DesktopNotesMenu.kt
@@ -112,7 +112,7 @@ fun DesktopNotesMenu(
                     showSortOptionsRequest = chooseNoteViewModel::showSortMenu,
                     hideSortOptionsRequest = chooseNoteViewModel::cancelSortMenu,
                     staggeredGridSelected =
-                    chooseNoteViewModel::staggeredGridArrangementSelected,
+                        chooseNoteViewModel::staggeredGridArrangementSelected,
                     gridSelected = chooseNoteViewModel::gridArrangementSelected,
                     listSelected = chooseNoteViewModel::listArrangementSelected,
                     selectSortOption = chooseNoteViewModel::sortingSelected,

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/actions/DesktopNoteActionsMenu.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/actions/DesktopNoteActionsMenu.kt
@@ -96,7 +96,8 @@ private fun MoreOptions(
                         contentDescription = "Configure directory",
                         tint = iconTintColor
                     )
-                }, onClick = configureDirectory,
+                },
+                onClick = configureDirectory,
                 text = {
                     Text(
                         "Configure directory",
@@ -112,7 +113,8 @@ private fun MoreOptions(
                         contentDescription = "Export",
                         tint = iconTintColor
                     )
-                }, onClick = exportAsMarkdownClick,
+                },
+                onClick = exportAsMarkdownClick,
                 text = {
                     Text("Export as Markdown", color = MaterialTheme.colorScheme.onPrimary)
                 }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/atoms/SortOptions.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/atoms/SortOptions.kt
@@ -2,9 +2,13 @@ package io.writeopia.note_menu.ui.screen.configuration.atoms
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.Sort
-import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.SwapVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -48,7 +52,8 @@ internal fun SortOptions(
                         contentDescription = "Sort by name",
                         tint = iconTintColor
                     )
-                }, onClick = {
+                },
+                onClick = {
                     selectSortOption(OrderBy.NAME)
                 },
                 text = {
@@ -63,7 +68,8 @@ internal fun SortOptions(
                         contentDescription = "Sort by creation",
                         tint = iconTintColor
                     )
-                }, onClick = {
+                },
+                onClick = {
                     selectSortOption(OrderBy.CREATE)
                 },
                 text = {
@@ -78,7 +84,8 @@ internal fun SortOptions(
                         contentDescription = "Sort by last update",
                         tint = iconTintColor
                     )
-                }, onClick = {
+                },
+                onClick = {
                     selectSortOption(OrderBy.UPDATE)
                 },
                 text = {

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/molecules/ConfigurationsMenu.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/molecules/ConfigurationsMenu.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.writeopia.commonui.options.slide.HorizontalOptions
 import io.writeopia.commonui.SlideInBox
+import io.writeopia.commonui.options.slide.HorizontalOptions
 import io.writeopia.note_menu.ui.screen.configuration.modifier.orderConfigModifierHorizontal
 import io.writeopia.sdk.persistence.core.sorting.OrderBy
 import kotlinx.coroutines.flow.Flow
@@ -68,7 +68,8 @@ internal fun BoxScope.MobileConfigurationsMenu(
             modifier = Modifier
                 .padding(12.dp)
                 .fillMaxWidth()
-                .clip(MaterialTheme.shapes.large
+                .clip(
+                    MaterialTheme.shapes.large
                 )
                 .background(MaterialTheme.colorScheme.surface)
                 .padding(16.dp),
@@ -221,7 +222,6 @@ private fun SortingSection(sortingSelected: (OrderBy) -> Unit) {
 }
 
 private fun Modifier.sortingOptionModifier(): Modifier = fillMaxWidth().padding(12.dp)
-
 
 @Preview
 @Composable

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/molecules/NotesConfigurationMenu.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/molecules/NotesConfigurationMenu.kt
@@ -5,16 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.writeopia.note_menu.ui.screen.configuration.atoms.ArrangementOptionsMenu
 import io.writeopia.note_menu.ui.screen.configuration.atoms.SortOptions

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/molecules/WorkspaceConfigurationDialog.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/configuration/molecules/WorkspaceConfigurationDialog.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.writeopia.note_menu.ui.screen.file.fileChooserSave
-import io.writeopia.theme.WriteopiaTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -106,5 +105,4 @@ private fun WorkspaceConfigurationDialogPreview() {
             modifier = Modifier.align(Alignment.Center)
         )
     }
-
 }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/documents/NoteItems.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/documents/NoteItems.kt
@@ -1,6 +1,6 @@
 package io.writeopia.note_menu.ui.screen.documents
 
-//import io.writeopia.appresourcers.R
+// import io.writeopia.appresourcers.R
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -38,11 +38,11 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.writeopia.common.utils.ResultData
 import io.writeopia.note_menu.data.model.NotesArrangement
 import io.writeopia.note_menu.ui.dto.MenuItemUi
 import io.writeopia.note_menu.ui.dto.NotesUi
 import io.writeopia.sdk.model.draganddrop.DropInfo
-import io.writeopia.sdk.model.draw.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.theme.WriteopiaTheme
@@ -54,7 +54,7 @@ import io.writeopia.ui.drawer.preview.CheckItemPreviewDrawer
 import io.writeopia.ui.drawer.preview.HeaderPreviewDrawer
 import io.writeopia.ui.drawer.preview.TextPreviewDrawer
 import io.writeopia.ui.drawer.preview.UnOrderedListItemPreviewDrawer
-import io.writeopia.common.utils.ResultData
+import io.writeopia.ui.model.DrawInfo
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val DOCUMENT_ITEM_TEST_TAG = "DocumentItem_"
@@ -127,7 +127,8 @@ fun NotesCards(
             Box(modifier = modifier.fillMaxSize()) {
                 Text(
                     modifier = Modifier.align(Alignment.Center),
-                    text = "Error!!"// stringResource(R.string.error_loading_notes)
+                    // stringResource(R.string.error_loading_notes)
+                    text = "Error!!"
                 )
             }
         }
@@ -509,7 +510,6 @@ fun DocumentItemPreview() {
     )
 }
 
-
 @Preview
 @Composable
 fun DocumentItemSelectedPreview() {
@@ -538,7 +538,6 @@ fun DocumentItemSelectedPreview() {
         modifier = Modifier.padding(10.dp)
     )
 }
-
 
 @Preview
 @Composable

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/file/FileChooserSave.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/file/FileChooserSave.kt
@@ -1,5 +1,3 @@
 package io.writeopia.note_menu.ui.screen.file
 
 expect fun fileChooserSave(title: String = "Choose file"): String?
-
-

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/menu/NotesMenuScreen.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/ui/screen/menu/NotesMenuScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import io.writeopia.model.ColorThemeOption
-import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.note_menu.data.model.NotesNavigation
 import io.writeopia.note_menu.ui.dto.MenuItemUi
 import io.writeopia.note_menu.viewmodel.ChooseNoteViewModel

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/ChooseNoteKmpViewModel.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/ChooseNoteKmpViewModel.kt
@@ -2,6 +2,11 @@ package io.writeopia.note_menu.viewmodel
 
 import io.writeopia.auth.core.data.User
 import io.writeopia.auth.core.manager.AuthManager
+import io.writeopia.common.utils.DISCONNECTED_USER_ID
+import io.writeopia.common.utils.KmpViewModel
+import io.writeopia.common.utils.ResultData
+import io.writeopia.common.utils.map
+import io.writeopia.common.utils.toBoolean
 import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.note_menu.data.model.NotesArrangement
 import io.writeopia.note_menu.data.model.NotesNavigation
@@ -16,11 +21,6 @@ import io.writeopia.sdk.import_document.json.WriteopiaJsonParser
 import io.writeopia.sdk.models.document.MenuItem
 import io.writeopia.sdk.persistence.core.sorting.OrderBy
 import io.writeopia.sdk.preview.PreviewParser
-import io.writeopia.common.utils.DISCONNECTED_USER_ID
-import io.writeopia.common.utils.KmpViewModel
-import io.writeopia.common.utils.ResultData
-import io.writeopia.common.utils.map
-import io.writeopia.common.utils.toBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -137,7 +137,6 @@ internal class ChooseNoteKmpViewModel(
                     },
                     notesArrangement = arrangement
                 )
-
             }
         }.stateIn(coroutineScope, SharingStarted.Lazily, ResultData.Idle())
     }
@@ -339,7 +338,6 @@ internal class ChooseNoteKmpViewModel(
     override fun onWriteLocallySelected() {
         handleStorage(::writeWorkspace, SyncRequest.WRITE)
     }
-
 
     private fun handleStorage(workspaceFunc: suspend (String) -> Unit, syncRequest: SyncRequest) {
         coroutineScope.launch(Dispatchers.Default) {

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/ChooseNoteViewModel.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/ChooseNoteViewModel.kt
@@ -1,10 +1,10 @@
 package io.writeopia.note_menu.viewmodel
 
+import io.writeopia.common.utils.ResultData
 import io.writeopia.note_menu.data.model.NotesArrangement
 import io.writeopia.note_menu.ui.dto.NotesUi
 import io.writeopia.sdk.models.document.MenuItem
 import io.writeopia.sdk.persistence.core.sorting.OrderBy
-import io.writeopia.common.utils.ResultData
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 
@@ -22,36 +22,63 @@ interface ChooseNoteViewModel : FolderController {
 
     //    fun requestDocuments(force: Boolean)
     fun handleMenuItemTap(id: String): Boolean
+
     suspend fun requestUser()
+
     fun showEditMenu()
+
     fun showSortMenu()
+
     fun cancelEditMenu()
+
     fun cancelSortMenu()
+
     fun directoryFilesAsMarkdown(path: String)
+
     fun loadFiles(filePaths: List<String>)
+
     fun onDocumentSelected(id: String, selected: Boolean)
+
     fun onSyncLocallySelected()
+
     fun configureDirectory()
+
     fun onWriteLocallySelected()
+
     fun clearSelection()
+
     fun listArrangementSelected()
+
     fun gridArrangementSelected()
+
     fun staggeredGridArrangementSelected()
+
     fun sortingSelected(orderBy: OrderBy)
+
     fun copySelectedNotes()
+
     fun deleteSelectedNotes()
+
     fun favoriteSelectedNotes()
+
     fun unSelectNotes()
+
     fun hideConfigSyncMenu()
+
     fun pathSelected(path: String)
+
     fun confirmWorkplacePath()
 }
 
 sealed interface UserState<T> {
     class Idle<T> : UserState<T>
+
     class Loading<T> : UserState<T>
+
     class ConnectedUser<T>(val data: T) : UserState<T>
+
     class UserNotReturned<T> : UserState<T>
+
     class DisconnectedUser<T>(val data: T) : UserState<T>
 }
 
@@ -80,7 +107,9 @@ sealed interface ConfigState {
 }
 
 enum class SyncRequest {
-    WRITE, READ_WRITE, CONFIGURE
+    WRITE,
+    READ_WRITE,
+    CONFIGURE
 }
 
 fun ConfigState.setPath(func: () -> String): ConfigState =

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/FolderController.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/FolderController.kt
@@ -5,9 +5,14 @@ import io.writeopia.note_menu.ui.dto.MenuItemUi
 
 interface FolderController {
     fun addFolder()
+
     fun editFolder(folder: MenuItemUi.FolderUi)
+
     fun updateFolder(folderEdit: Folder)
+
     fun deleteFolder(id: String)
+
     fun stopEditingFolder()
+
     fun moveToFolder(menuItemUi: MenuItemUi, parentId: String)
 }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/FolderStateController.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/note_menu/viewmodel/FolderStateController.kt
@@ -13,12 +13,12 @@ import kotlinx.coroutines.launch
 class FolderStateController(
     private val notesUseCase: NotesUseCase,
     private val authManager: AuthManager,
-): FolderController {
+) : FolderController {
     private lateinit var coroutineScope: CoroutineScope
 
     private var localUserId: String? = null
 
-    //Todo: Change this to a usecase
+    // Todo: Change this to a usecase
     private val _editingFolder = MutableStateFlow<MenuItemUi.FolderUi?>(null)
     val editingFolderState = _editingFolder.asStateFlow()
 

--- a/application/features/note_menu/src/jsMain/kotlin/io/writeopia/note_menu/ui/screen/menu/NotesMenuScreen.js.kt
+++ b/application/features/note_menu/src/jsMain/kotlin/io/writeopia/note_menu/ui/screen/menu/NotesMenuScreen.js.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import io.writeopia.model.ColorThemeOption
-import io.writeopia.note_menu.data.model.Folder
 import io.writeopia.note_menu.data.model.NotesNavigation
 import io.writeopia.note_menu.ui.dto.MenuItemUi
 import io.writeopia.note_menu.ui.screen.DesktopNotesMenu

--- a/writeopia/src/commonMain/kotlin/io/writeopia/sdk/manager/WriteopiaManager.kt
+++ b/writeopia/src/commonMain/kotlin/io/writeopia/sdk/manager/WriteopiaManager.kt
@@ -107,9 +107,12 @@ class WriteopiaManager(
         )
 
     /**
-     * At the moment it is only possible to check items not inside groups. Todo: Fix it!
+     * Changes the state of a story step based of the stateChange
      *
-     * @param stateChange [Action.StoryStateChange]
+     * @param stateChange [Action.StoryStateChange] the actual change.
+     * @param storyState The current state of the document
+     *
+     * @return [StoryState] The current state
      */
     fun changeStoryState(
         stateChange: Action.StoryStateChange,

--- a/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/action/Action.kt
+++ b/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/action/Action.kt
@@ -16,7 +16,12 @@ sealed class Action {
 
     data class Move(val storyStep: StoryStep, val positionFrom: Int, val positionTo: Int) : Action()
 
-    data class StoryStateChange(val storyStep: StoryStep, val position: Int) : Action()
+    data class StoryStateChange(
+        val storyStep: StoryStep,
+        val position: Int,
+        val selectionStart: Int? = null,
+        val selectionEnd: Int? = null
+    ) : Action()
 
     data class Merge(
         val receiver: StoryStep,

--- a/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/story/Selection.kt
+++ b/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/story/Selection.kt
@@ -1,11 +1,11 @@
 package io.writeopia.sdk.model.story
 
-
 data class Selection(val start: Int, val end: Int) {
     companion object {
         fun start(): Selection = Selection(0, 0)
+
         fun end(): Selection = Selection(Int.MAX_VALUE, Int.MAX_VALUE)
+
         fun fromPosition(position: Int) = Selection(position, position)
     }
 }
-

--- a/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/story/Selection.kt
+++ b/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/story/Selection.kt
@@ -1,6 +1,5 @@
-package io.writeopia.ui.model
+package io.writeopia.sdk.model.story
 
-import androidx.compose.ui.text.TextRange
 
 data class Selection(val start: Int, val end: Int) {
     companion object {
@@ -10,4 +9,3 @@ data class Selection(val start: Int, val end: Int) {
     }
 }
 
-fun Selection.toTextRange() = TextRange(start = start, end = end)

--- a/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/story/StoryState.kt
+++ b/writeopia/src/commonMain/kotlin/io/writeopia/sdk/model/story/StoryState.kt
@@ -9,5 +9,6 @@ import io.writeopia.sdk.models.story.StoryStep
 data class StoryState(
     val stories: Map<Int, StoryStep>,
     val lastEdit: LastEdit,
-    val focusId: String? = null
+    val focusId: String? = null,
+    val selection: Selection = Selection.start()
 )

--- a/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/content/ImageDrawer.kt
+++ b/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/content/ImageDrawer.kt
@@ -27,7 +27,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import io.writeopia.sdk.model.action.Action
 import io.writeopia.sdk.model.draganddrop.DropInfo
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.draganddrop.target.DragTarget
 import io.writeopia.ui.draganddrop.target.DropTarget

--- a/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
+++ b/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import io.writeopia.sdk.model.draganddrop.DropInfo
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.components.SwipeBox
 import io.writeopia.ui.draganddrop.target.DragRowTargetWithDragItem

--- a/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/content/VideoDrawer.kt
+++ b/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/content/VideoDrawer.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import coil.request.videoFrameMillis
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.drawer.StoryStepDrawer
 

--- a/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/factory/DefaultDrawersAndroid.kt
+++ b/writeopia_ui/src/androidMain/kotlin/io/writeopia/ui/drawer/factory/DefaultDrawersAndroid.kt
@@ -13,7 +13,6 @@ import io.writeopia.ui.drawer.content.defaultImageShape
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.StoryStepDrawer
 import io.writeopia.ui.drawer.content.RowGroupDrawer
-import io.writeopia.ui.edition.TextCommandHandler
 import io.writeopia.ui.manager.WriteopiaStateManager
 
 object DefaultDrawersAndroid : DrawersFactory {
@@ -25,7 +24,6 @@ object DefaultDrawersAndroid : DrawersFactory {
         editable: Boolean,
         groupsBackgroundColor: Color,
         onHeaderClick: () -> Unit,
-        textCommandHandler: TextCommandHandler
     ): Map<Int, StoryStepDrawer> {
         val imageDrawer = ImageDrawer(
             containerModifier = Modifier::defaultImageShape,
@@ -44,7 +42,6 @@ object DefaultDrawersAndroid : DrawersFactory {
             editable,
             groupsBackgroundColor,
             onHeaderClick,
-            textCommandHandler,
             lineBreakByContent = true,
             eventListener = KeyEventListenerFactory.android(
                 manager,

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/WriteopiaEditor.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/WriteopiaEditor.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
-import io.writeopia.sdk.model.story.DrawState
+import io.writeopia.ui.model.DrawInfo
+import io.writeopia.ui.model.DrawState
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.draganddrop.target.DraggableScreen
 import io.writeopia.ui.drawer.StoryStepDrawer
@@ -51,7 +51,8 @@ fun WriteopiaEditor(
                                         focusId = storyState.focusId,
                                         position = index,
                                         extraData = mapOf("listSize" to storyState.stories.size),
-                                        selectMode = drawStory.isSelected
+                                        selectMode = drawStory.isSelected,
+                                        selection = drawStory.cursor
                                     )
                                 )
                             }

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/WriteopiaEditorBox.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/WriteopiaEditorBox.kt
@@ -3,8 +3,8 @@ package io.writeopia.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import io.writeopia.sdk.model.draw.DrawInfo
-import io.writeopia.sdk.model.story.DrawState
+import io.writeopia.ui.model.DrawInfo
+import io.writeopia.ui.model.DrawState
 import io.writeopia.ui.draganddrop.target.DraggableScreen
 import io.writeopia.ui.drawer.StoryStepDrawer
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/SimpleTextDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/SimpleTextDrawer.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 
 interface SimpleTextDrawer {

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/StoryStepDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/StoryStepDrawer.kt
@@ -1,7 +1,7 @@
 package io.writeopia.ui.drawer
 
 import androidx.compose.runtime.Composable
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 
 /**

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/AddButtonDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/AddButtonDrawer.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.drawer.StoryStepDrawer
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/CheckItemDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/CheckItemDrawer.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.writeopia.sdk.model.action.Action
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.SimpleTextDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/HeaderDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/HeaderDrawer.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.Decoration
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
@@ -110,9 +110,9 @@ fun headerDrawer(
         drawer = {
             TextDrawer(
                 modifier = Modifier.align(Alignment.BottomStart),
-                onTextEdit = manager::changeStoryText,
+                onTextEdit = manager::handleTextInput,
                 onKeyEvent = onKeyEvent,
-                onLineBreak = manager::onLineBreak,
+//                onLineBreak = manager::onLineBreak,
                 lineBreakByContent = lineBreakByContent,
                 emptyErase = EmptyErase.DISABLED,
                 textStyle = {
@@ -137,8 +137,7 @@ private fun HeaderDrawerStepPreview() {
         drawer = {
             TextDrawer(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 16.dp, bottom = 16.dp),
-                onTextEdit = { },
-                onLineBreak = { },
+                onTextEdit = { _, _, _, _ -> },
                 textStyle = {
                     MaterialTheme.typography.headlineMedium.copy(
                         fontWeight = FontWeight.Bold,
@@ -162,8 +161,7 @@ private fun HeaderDrawerStepPreviewNoColor() {
         drawer = {
             TextDrawer(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 16.dp, bottom = 16.dp),
-                onTextEdit = { },
-                onLineBreak = { },
+                onTextEdit = { _, _, _, _ -> },
                 textStyle = {
                     MaterialTheme.typography.headlineMedium.copy(
                         fontWeight = FontWeight.Bold,

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/HeaderDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/HeaderDrawer.kt
@@ -112,7 +112,6 @@ fun headerDrawer(
                 modifier = Modifier.align(Alignment.BottomStart),
                 onTextEdit = manager::handleTextInput,
                 onKeyEvent = onKeyEvent,
-//                onLineBreak = manager::onLineBreak,
                 lineBreakByContent = lineBreakByContent,
                 emptyErase = EmptyErase.DISABLED,
                 textStyle = {

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/LastEmptySpace.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/LastEmptySpace.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.writeopia.sdk.model.action.Action
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.draganddrop.target.DropTarget
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/RowGroupDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/RowGroupDrawer.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.drawer.StoryStepDrawer
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/SpaceDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/SpaceDrawer.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.writeopia.sdk.model.action.Action
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.draganddrop.target.DropTarget
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/SwipeMessageDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/SwipeMessageDrawer.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.SimpleTextDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextDrawer.kt
@@ -6,7 +6,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
@@ -21,13 +25,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.action.Action
-import io.writeopia.sdk.model.draw.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.SimpleTextDrawer
-import io.writeopia.ui.edition.TextCommandHandler
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.ui.model.EmptyErase
+import io.writeopia.ui.model.TextInput
+import io.writeopia.ui.model.toTextRange
 import io.writeopia.ui.utils.defaultTextStyle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,12 +47,10 @@ class TextDrawer(
     private val onKeyEvent: (KeyEvent, TextFieldValue, StoryStep, Int, EmptyErase) -> Boolean =
         { _, _, _, _, _ -> false },
     private val textStyle: @Composable (StoryStep) -> TextStyle = { defaultTextStyle(it) },
-    private val onTextEdit: (Action.StoryStateChange) -> Unit = { },
-    private val commandHandler: TextCommandHandler = TextCommandHandler(emptyMap()),
+    private val onTextEdit: (TextInput, Int, Boolean, Boolean) -> Unit = { _, _, _, _ -> },
     private val allowLineBreaks: Boolean = false,
     private val lineBreakByContent: Boolean = true,
     private val emptyErase: EmptyErase = EmptyErase.CHANGE_TYPE,
-    private val onLineBreak: (Action.LineBreak) -> Unit = {},
     override var onFocusChanged: (Int, FocusState) -> Unit = { _, _ -> },
     private val selectionState: StateFlow<Boolean>,
     private val onSelectionLister: (Int) -> Unit
@@ -62,10 +64,8 @@ class TextDrawer(
         focusRequester: FocusRequester?,
         decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit
     ) {
-        var inputText by remember {
-            val text = step.text ?: ""
-            mutableStateOf(TextFieldValue(text, TextRange(text.length)))
-        }
+        val text = step.text ?: ""
+        val inputText = TextFieldValue(text, drawInfo.selection.toTextRange())
 
         val selectionState by selectionState.collectAsState()
 
@@ -102,26 +102,16 @@ class TextDrawer(
             value = inputText,
             enabled = !selectionState,
             onValueChange = { value ->
-                val text = value.text
-
-                inputText = if (lineBreakByContent && !allowLineBreaks && text.contains("\n")) {
-                    val newStep = step.copy(text = text)
-                    onLineBreak(Action.LineBreak(newStep, drawInfo.position))
-
-                    val newText = text.split("\n", limit = 2)[0]
-                    TextFieldValue(newText, TextRange(newText.length))
-                } else {
-                    val newText = if (allowLineBreaks) {
-                        text
-                    } else {
-                        text.replace("\n", "")
-                    }
-                    val newStep = step.copy(text = newText)
-                    onTextEdit(Action.StoryStateChange(newStep, drawInfo.position))
-                    commandHandler.handleCommand(text, newStep, drawInfo.position)
-
-                    value.copy(text = newText)
-                }
+                //The value is updated in the Compose for performance reasons. If the text input is
+                //sent to the ViewModel, it will perform many calculations to show the new text
+                //which can be a costly operation for long documents.
+                println("value.text: ${value.text}, value.selection.start: ${value.selection.start}")
+                onTextEdit(
+                    TextInput(value.text, value.selection.start, value.selection.end),
+                    drawInfo.position,
+                    lineBreakByContent,
+                    allowLineBreaks
+                )
             },
             keyboardOptions = KeyboardOptions(
                 capitalization = KeyboardCapitalization.Sentences
@@ -132,6 +122,40 @@ class TextDrawer(
             decorationBox = decorationBox,
         )
     }
+
+//    private fun parseInputText(
+//        input: TextFieldValue,
+//        step: StoryStep,
+//        drawInfo: DrawInfo
+//    ): TextFieldValue {
+//        val text = input.text
+//
+//        return if (lineBreakByContent && !allowLineBreaks && text.contains("\n")) {
+//            val newStep = step.copy(text = text)
+//            onLineBreak(Action.LineBreak(newStep, drawInfo.position))
+//
+//            val newText = text.split("\n", limit = 2)[0]
+//            TextFieldValue(newText, TextRange(newText.length))
+//        } else {
+//            val newText = if (allowLineBreaks) {
+//                text
+//            } else {
+//                text.replace("\n", "")
+//            }
+//            val newStep = step.copy(text = newText)
+//            onTextEdit(
+//                Action.StoryStateChange(
+//                    newStep,
+//                    drawInfo.position,
+//                    selectionStart = input.selection.start,
+//                    selectionEnd = input.selection.end
+//                )
+//            )
+//            commandHandler.handleCommand(text, newStep, drawInfo.position)
+//
+//            input.copy(text = newText)
+//        }
+//    }
 }
 
 @Preview

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextDrawer.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.unit.dp
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.SimpleTextDrawer
+import io.writeopia.ui.extensions.toTextRange
 import io.writeopia.ui.model.DrawInfo
 import io.writeopia.ui.model.EmptyErase
 import io.writeopia.ui.model.TextInput
-import io.writeopia.ui.model.toTextRange
 import io.writeopia.ui.utils.defaultTextStyle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextDrawer.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
@@ -102,10 +101,6 @@ class TextDrawer(
             value = inputText,
             enabled = !selectionState,
             onValueChange = { value ->
-                //The value is updated in the Compose for performance reasons. If the text input is
-                //sent to the ViewModel, it will perform many calculations to show the new text
-                //which can be a costly operation for long documents.
-                println("value.text: ${value.text}, value.selection.start: ${value.selection.start}")
                 onTextEdit(
                     TextInput(value.text, value.selection.start, value.selection.end),
                     drawInfo.position,
@@ -122,40 +117,6 @@ class TextDrawer(
             decorationBox = decorationBox,
         )
     }
-
-//    private fun parseInputText(
-//        input: TextFieldValue,
-//        step: StoryStep,
-//        drawInfo: DrawInfo
-//    ): TextFieldValue {
-//        val text = input.text
-//
-//        return if (lineBreakByContent && !allowLineBreaks && text.contains("\n")) {
-//            val newStep = step.copy(text = text)
-//            onLineBreak(Action.LineBreak(newStep, drawInfo.position))
-//
-//            val newText = text.split("\n", limit = 2)[0]
-//            TextFieldValue(newText, TextRange(newText.length))
-//        } else {
-//            val newText = if (allowLineBreaks) {
-//                text
-//            } else {
-//                text.replace("\n", "")
-//            }
-//            val newStep = step.copy(text = newText)
-//            onTextEdit(
-//                Action.StoryStateChange(
-//                    newStep,
-//                    drawInfo.position,
-//                    selectionStart = input.selection.start,
-//                    selectionEnd = input.selection.end
-//                )
-//            )
-//            commandHandler.handleCommand(text, newStep, drawInfo.position)
-//
-//            input.copy(text = newText)
-//        }
-//    }
 }
 
 @Preview

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.drawer.SimpleTextDrawer
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/UnOrderedListItemDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/content/UnOrderedListItemDrawer.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.SimpleTextDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/CommonDrawers.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/CommonDrawers.kt
@@ -26,7 +26,6 @@ import io.writeopia.ui.drawer.content.checkItemDrawer
 import io.writeopia.ui.drawer.content.headerDrawer
 import io.writeopia.ui.drawer.content.swipeTextDrawer
 import io.writeopia.ui.drawer.content.unOrderedListItemDrawer
-import io.writeopia.ui.edition.TextCommandHandler
 import io.writeopia.ui.manager.WriteopiaStateManager
 import io.writeopia.ui.model.EmptyErase
 import io.writeopia.ui.utils.codeBlockStyle
@@ -48,7 +47,6 @@ object CommonDrawers {
         editable: Boolean = false,
         groupsBackgroundColor: Color = Color.Transparent,
         onHeaderClick: () -> Unit = {},
-        textCommandHandler: TextCommandHandler = TextCommandHandler.defaultCommands(manager),
         dragIconWidth: Dp = DRAG_ICON_WIDTH.dp,
         lineBreakByContent: Boolean,
         eventListener: (KeyEvent, TextFieldValue, StoryStep, Int, EmptyErase) -> Boolean,
@@ -57,16 +55,12 @@ object CommonDrawers {
             modifier = Modifier
                 .padding(horizontal = LARGE_START_PADDING.dp)
                 .clip(shape = defaultBorder)
-                .background(groupsBackgroundColor)
-                .let { modifierLet ->
-                    modifierLet
-                },
+                .background(groupsBackgroundColor),
             dragIconWidth = DRAG_ICON_WIDTH.dp,
             onSelected = manager::onSelected,
             messageDrawer = {
                 messageDrawer(
                     manager = manager,
-                    textCommandHandler = textCommandHandler,
                     eventListener = eventListener,
                     allowLineBreaks = true,
                     lineBreakByContent = lineBreakByContent,
@@ -86,7 +80,6 @@ object CommonDrawers {
             messageDrawer = {
                 messageDrawer(
                     manager = manager,
-                    textCommandHandler = TextCommandHandler.noCommands(),
                     eventListener = eventListener,
                     textStyle = { codeBlockStyle() },
                     allowLineBreaks = true,
@@ -104,7 +97,6 @@ object CommonDrawers {
         ) {
             messageDrawer(
                 manager = manager,
-                textCommandHandler = textCommandHandler,
                 eventListener = eventListener,
                 lineBreakByContent = lineBreakByContent,
                 emptyErase = EmptyErase.DELETE,
@@ -119,7 +111,6 @@ object CommonDrawers {
         ) {
             messageDrawer(
                 manager,
-                textCommandHandler = textCommandHandler,
                 eventListener = eventListener,
                 emptyErase = EmptyErase.CHANGE_TYPE,
                 lineBreakByContent = lineBreakByContent,
@@ -135,7 +126,6 @@ object CommonDrawers {
             ) {
                 messageDrawer(
                     manager,
-                    textCommandHandler = textCommandHandler,
                     eventListener = eventListener,
                     emptyErase = EmptyErase.CHANGE_TYPE,
                     lineBreakByContent = lineBreakByContent,
@@ -184,7 +174,6 @@ object CommonDrawers {
         manager: WriteopiaStateManager,
         modifier: Modifier = Modifier,
         textStyle: @Composable (StoryStep) -> TextStyle = { defaultTextStyle(it) },
-        textCommandHandler: TextCommandHandler = TextCommandHandler.defaultCommands(manager),
         allowLineBreaks: Boolean = false,
         lineBreakByContent: Boolean,
         emptyErase: EmptyErase,

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/CommonDrawers.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/CommonDrawers.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.key.KeyEvent
@@ -195,10 +194,8 @@ object CommonDrawers {
         return TextDrawer(
             modifier = modifier.weight(1F),
             onKeyEvent = eventListener,
-            onTextEdit = manager::changeStoryText,
+            onTextEdit = manager::handleTextInput,
             textStyle = textStyle,
-            commandHandler = textCommandHandler,
-            onLineBreak = manager::onLineBreak,
             onFocusChanged = { position, focus ->
                 manager.onFocusChange(position, focus.isFocused)
             } ,

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/DrawersFactory.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/DrawersFactory.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import io.writeopia.ui.drawer.StoryStepDrawer
-import io.writeopia.ui.edition.TextCommandHandler
 import io.writeopia.ui.manager.WriteopiaStateManager
 
 interface DrawersFactory {
@@ -16,6 +15,5 @@ interface DrawersFactory {
         editable: Boolean,
         groupsBackgroundColor: Color,
         onHeaderClick: () -> Unit,
-        textCommandHandler: TextCommandHandler,
     ): Map<Int, StoryStepDrawer>
 }

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/KeyEventListenerFactory.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/factory/KeyEventListenerFactory.kt
@@ -21,7 +21,6 @@ object KeyEventListenerFactory {
                 isEmptyErase(keyEvent, inputText) -> {
                     when (onEmptyErase) {
                         EmptyErase.DELETE -> {
-                            println("EmptyErase.DELETE inputText: ${inputText.text}")
                             manager.onErase(Action.EraseStory(step, position))
                         }
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/CheckItemPreviewDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/CheckItemPreviewDrawer.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/HeaderPreviewDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/HeaderPreviewDrawer.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/TextPreviewDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/TextPreviewDrawer.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/UnOrderedListItemPreviewDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/UnOrderedListItemPreviewDrawer.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
 import io.writeopia.ui.drawer.StoryStepDrawer

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/edition/TextCommandHandler.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/edition/TextCommandHandler.kt
@@ -31,8 +31,6 @@ class TextCommandHandler(private val commandsMap: Map<Command, (StoryStep, Int) 
         fun noCommands(): TextCommandHandler = TextCommandHandler(emptyMap())
 
         fun defaultCommands(manager: WriteopiaStateManager): TextCommandHandler {
-            val background = Color.Black.toArgb()
-
             return TextCommandHandler(
                 mapOf(
                     CommandFactory.checkItem() to { _, position ->

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/extensions/SelectionExtensions.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/extensions/SelectionExtensions.kt
@@ -1,0 +1,6 @@
+package io.writeopia.ui.extensions
+
+import androidx.compose.ui.text.TextRange
+import io.writeopia.sdk.model.story.Selection
+
+fun Selection.toTextRange() = TextRange(start = start, end = end)

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/keyboard/KeyboardEvent.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/keyboard/KeyboardEvent.kt
@@ -1,5 +1,5 @@
 package io.writeopia.ui.keyboard
 
 enum class KeyboardEvent {
-    MOVE_UP, MOVE_DOWN, IDLE
+    MOVE_UP, MOVE_DOWN, DELETE, IDLE
 }

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/manager/WriteopiaStateManager.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/manager/WriteopiaStateManager.kt
@@ -9,8 +9,6 @@ import io.writeopia.sdk.model.action.Action
 import io.writeopia.sdk.model.action.BackstackAction
 import io.writeopia.sdk.model.document.DocumentInfo
 import io.writeopia.sdk.model.document.info
-import io.writeopia.sdk.model.story.DrawState
-import io.writeopia.sdk.model.story.DrawStory
 import io.writeopia.sdk.model.story.LastEdit
 import io.writeopia.sdk.model.story.StoryState
 import io.writeopia.sdk.models.command.CommandInfo
@@ -26,7 +24,12 @@ import io.writeopia.sdk.utils.extensions.toEditState
 import io.writeopia.ui.backstack.BackstackHandler
 import io.writeopia.ui.backstack.BackstackInform
 import io.writeopia.ui.backstack.BackstackManager
+import io.writeopia.ui.edition.TextCommandHandler
 import io.writeopia.ui.keyboard.KeyboardEvent
+import io.writeopia.ui.model.DrawState
+import io.writeopia.ui.model.DrawStory
+import io.writeopia.ui.model.Selection
+import io.writeopia.ui.model.TextInput
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -71,11 +74,19 @@ class WriteopiaStateManager(
                         moveToNext()
                     }
 
+                    KeyboardEvent.DELETE -> {
+                        if (_positionsOnEdit.value.isNotEmpty()) {
+                            deleteSelection()
+                        }
+                    }
+
                     KeyboardEvent.IDLE -> {}
                 }
             }
         }
     }
+
+    private val commandHandler = TextCommandHandler.defaultCommands(this)
 
     private var lastStateChange: Action.StoryStateChange? = null
 
@@ -99,6 +110,8 @@ class WriteopiaStateManager(
 
     private val _positionsOnEdit = MutableStateFlow(setOf<Int>())
     val onEditPositions = _positionsOnEdit.asStateFlow()
+
+    private val selection = MutableStateFlow(Selection.start())
 
     private var sharedEditionManager: SharedEditionManager? = null
 
@@ -129,15 +142,20 @@ class WriteopiaStateManager(
             storyState to documentInfo
         }
 
-    val toDraw: Flow<DrawState> = combine(_positionsOnEdit, currentStory) { positions, storyState ->
-        val focus = storyState.focusId
+    val toDraw: Flow<DrawState> =
+        combine(_positionsOnEdit, selection, currentStory) { positions, selections, storyState ->
+            val focus = storyState.focusId
 
-        val toDrawStories = storyState.stories.mapValues { (position, storyStep) ->
-            DrawStory(storyStep, positions.contains(position))
+            val toDrawStories = storyState.stories.mapValues { (position, storyStep) ->
+                DrawStory(
+                    storyStep = storyStep,
+                    cursor = selections,
+                    isSelected = positions.contains(position)
+                )
+            }
+
+            DrawState(toDrawStories, focus)
         }
-
-        DrawState(toDrawStories, focus)
-    }
 
     private var _initialized = false
 
@@ -216,29 +234,6 @@ class WriteopiaStateManager(
     }
 
     /**
-     * Moves the focus to the next available [StoryStep] if it can't find a step to focus, it
-     * creates a new [StoryStep] at the end of the document.
-     *
-     * @param position Int
-     */
-    private fun nextFocusOrCreate(position: Int) {
-        coroutineScope.launch(dispatcher) {
-            _currentStory.value =
-                writeopiaManager.nextFocusOrCreate(position, _currentStory.value)
-        }
-    }
-
-    private fun moveToNext() {
-        val focusPosition = currentFocus()?.let { (position, _) -> position } ?: 0
-        nextFocusOrCreate(focusPosition + 1)
-    }
-
-    private fun moveToPrevious() {
-        val focusPosition = currentFocus()?.let { (position, _) -> position } ?: 0
-        nextFocusOrCreate(max(focusPosition - 1, 0))
-    }
-
-    /**
      * Merges two [StoryStep] into a group. This can be used to merge two images into a message
      * group or any other kind of group.
      *
@@ -305,28 +300,6 @@ class WriteopiaStateManager(
         }
     }
 
-    private fun toggleStateForStories(onEdit: Set<Int>, storyTypes: StoryTypes) {
-        val currentStories = currentStory.value.stories
-
-        onEdit.forEach { position ->
-            val story = currentStories[position]
-            if (story != null) {
-                val newType = if (story.type == storyTypes.type) {
-                    StoryTypes.TEXT
-                } else {
-                    storyTypes
-                }
-
-                changeStoryState(
-                    Action.StoryStateChange(
-                        storyStep = story.copy(type = newType.type),
-                        position = position
-                    )
-                )
-            }
-        }
-    }
-
     /**
      * Click lister when user clicks in the menu to add a list item
      */
@@ -349,49 +322,12 @@ class WriteopiaStateManager(
 //        changeCurrentStoryType(StoryTypes.CODE_BLOCK)
     }
 
-    private fun changeCurrentStoryType(storyTypes: StoryTypes) {
-        changeCurrentStoryState { storyStep ->
-            val newType = if (storyStep.type == storyTypes.type) {
-                StoryTypes.TEXT.type
-            } else {
-                storyTypes.type
-            }
-
-            storyStep.copy(type = newType)
-        }
-    }
-
-    private fun changeCurrentStoryState(stateChange: (StoryStep) -> StoryStep) {
-        val currentStepEntry = currentFocus()
-
-        if (currentStepEntry != null) {
-            changeStoryState(
-                Action.StoryStateChange(
-                    stateChange(currentStepEntry.second),
-                    currentStepEntry.first
-                )
-            )
-        }
-    }
-
-    private fun currentFocus(): Pair<Int, StoryStep>? {
-        val currentFocusId = currentStory.value.focusId
-
-        return _currentStory.value
-            .stories
-            .entries
-            .find { (_, step) -> step.id == currentFocusId }
-            ?.let { (position, step) ->
-                position to step
-            }
-    }
-
     /**
      * At the moment it is only possible to check items not inside groups. Todo: Fix it!
      *
      * @param stateChange [Action.StoryStateChange]
      */
-    fun changeStoryText(stateChange: Action.StoryStateChange) {
+    private fun changeStoryText(stateChange: Action.StoryStateChange) {
         val backstackAction = _currentStory.value.stories[stateChange.position]?.let { oldStory ->
             BackstackAction.StoryTextChange(
                 storyStep = oldStory,
@@ -400,21 +336,6 @@ class WriteopiaStateManager(
         }
 
         changeStoryStateAndTrackIt(stateChange, backstackAction)
-    }
-
-    private fun changeStoryStateAndTrackIt(
-        stateChange: Action.StoryStateChange,
-        backstackAction: BackstackAction?
-    ) {
-        if (lastStateChange == stateChange) return
-        lastStateChange = stateChange
-
-        writeopiaManager.changeStoryState(stateChange, _currentStory.value)?.let { state ->
-            _currentStory.value = state
-            backstackAction?.let { action ->
-                backStackManager.addAction(action)
-            }
-        }
     }
 
     /**
@@ -454,6 +375,7 @@ class WriteopiaStateManager(
                 backStackManager.addAction(BackstackAction.Add(newStory, newPosition))
                 _currentStory.value = newState
                 _scrollToPosition.value = info.first
+                selection.value = Selection.start()
             }
         }
     }
@@ -559,16 +481,20 @@ class WriteopiaStateManager(
                 _currentStory.value.stories,
                 eraseStory.position
             )
+            val previousStory = previousInfo?.first
 
             _currentStory.value = writeopiaManager.onErase(eraseStory, _currentStory.value)
 
             val backstackAction = BackstackAction.Erase(
                 erasedStep = eraseStory.storyStep,
-                receivingStep = previousInfo?.first,
+                receivingStep = previousStory,
                 erasedPosition = eraseStory.position,
                 receivingPosition = previousInfo?.second
             )
 
+            previousStory?.text?.length?.let(Selection::fromPosition)?.let {
+                selection.value = it
+            }
             backStackManager.addAction(backstackAction)
         }
     }
@@ -593,13 +519,6 @@ class WriteopiaStateManager(
     }
 
     /**
-     * Cancels the current selection.
-     */
-    private fun cancelSelection() {
-        _positionsOnEdit.value = emptySet()
-    }
-
-    /**
      * Clears the [WriteopiaStateManager]. Use this in the onCleared of your ViewModel.
      */
     fun onClear() {
@@ -608,6 +527,144 @@ class WriteopiaStateManager(
         }.invokeOnCompletion {
             coroutineScope.cancel()
         }
+    }
+
+    /**
+     * Moves the focus to the next available [StoryStep] if it can't find a step to focus, it
+     * creates a new [StoryStep] at the end of the document.
+     *
+     * @param position Int
+     */
+    private fun nextFocusOrCreate(position: Int) {
+        coroutineScope.launch(dispatcher) {
+            _currentStory.value =
+                writeopiaManager.nextFocusOrCreate(position, _currentStory.value)
+        }
+    }
+
+    private fun moveToNext() {
+        val focusPosition = currentFocus()?.let { (position, _) -> position } ?: 0
+        nextFocusOrCreate(focusPosition + 1)
+    }
+
+    private fun moveToPrevious() {
+        val focusPosition = currentFocus()?.let { (position, _) -> position } ?: 0
+        nextFocusOrCreate(max(focusPosition - 1, 0))
+    }
+
+    private fun toggleStateForStories(onEdit: Set<Int>, storyTypes: StoryTypes) {
+        val currentStories = currentStory.value.stories
+
+        onEdit.forEach { position ->
+            val story = currentStories[position]
+            if (story != null) {
+                val newType = if (story.type == storyTypes.type) {
+                    StoryTypes.TEXT
+                } else {
+                    storyTypes
+                }
+
+                changeStoryState(
+                    Action.StoryStateChange(
+                        storyStep = story.copy(type = newType.type),
+                        position = position,
+                        selectionStart = selection.value.start,
+                        selectionEnd = selection.value.end
+                    )
+                )
+            }
+        }
+    }
+
+    private fun changeCurrentStoryType(storyTypes: StoryTypes) {
+        changeCurrentStoryState { storyStep ->
+            val newType = if (storyStep.type == storyTypes.type) {
+                StoryTypes.TEXT.type
+            } else {
+                storyTypes.type
+            }
+
+            storyStep.copy(type = newType)
+        }
+    }
+
+    private fun changeCurrentStoryState(stateChange: (StoryStep) -> StoryStep) {
+        val currentStepEntry = currentFocus()
+
+        if (currentStepEntry != null) {
+            changeStoryState(
+                Action.StoryStateChange(
+                    stateChange(currentStepEntry.second),
+                    currentStepEntry.first
+                )
+            )
+        }
+    }
+
+    private fun currentFocus(): Pair<Int, StoryStep>? {
+        val currentFocusId = currentStory.value.focusId
+
+        return _currentStory.value
+            .stories
+            .entries
+            .find { (_, step) -> step.id == currentFocusId }
+            ?.let { (position, step) ->
+                position to step
+            }
+    }
+
+    private fun changeStoryStateAndTrackIt(
+        stateChange: Action.StoryStateChange,
+        backstackAction: BackstackAction?
+    ) {
+        if (lastStateChange == stateChange) return
+        lastStateChange = stateChange
+
+        writeopiaManager.changeStoryState(stateChange, _currentStory.value)?.let { state ->
+            _currentStory.value = state
+            backstackAction?.let(backStackManager::addAction)
+        }
+
+        selection.value = Selection(stateChange.selectionStart ?: 0, stateChange.selectionEnd ?: 0)
+    }
+
+    fun handleTextInput(
+        input: TextInput,
+        position: Int,
+        lineBreakByContent: Boolean,
+        allowLineBreaks: Boolean
+    ) {
+        val text = input.text
+        val step = _currentStory.value.stories[position] ?: return
+
+        if (lineBreakByContent && !allowLineBreaks && text.contains("\n")) {
+            val newStep = step.copy(text = text)
+            onLineBreak(Action.LineBreak(newStep, position))
+        } else {
+            val newText = if (allowLineBreaks) {
+                text
+            } else {
+                text.replace("\n", "")
+            }
+            val newStep = step.copy(text = newText)
+
+            commandHandler.handleCommand(text, newStep, position)
+            changeStoryText(
+                Action.StoryStateChange(
+                    newStep,
+                    position,
+                    selectionStart = input.start,
+                    selectionEnd = input.end
+                )
+            )
+        }
+    }
+
+    /**
+     * Cancels the current selection.
+     */
+    private fun cancelSelection() {
+        _positionsOnEdit.value = emptySet()
     }
 
     companion object {

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/manager/WriteopiaStateManager.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/manager/WriteopiaStateManager.kt
@@ -642,7 +642,6 @@ class WriteopiaStateManager(
         lineBreakByContent: Boolean,
         allowLineBreaks: Boolean
     ) {
-        println("handleTextInput. input.text: ${input.text}")
         val text = input.text
         val step = _currentStory.value.stories[position] ?: return
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawInfo.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawInfo.kt
@@ -1,4 +1,4 @@
-package io.writeopia.sdk.model.draw
+package io.writeopia.ui.model
 
 /**
  * The class holds the information of the content to be draw by the SDK.
@@ -16,5 +16,5 @@ data class DrawInfo(
     val position: Int = 0,
     val extraData: Map<String, Any> = emptyMap(),
     val selectMode: Boolean = false,
-//    val textRange: TextRange //Todo: Populate this!!
+    val selection: Selection = Selection.start()
 )

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawInfo.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawInfo.kt
@@ -1,5 +1,7 @@
 package io.writeopia.ui.model
 
+import io.writeopia.sdk.model.story.Selection
+
 /**
  * The class holds the information of the content to be draw by the SDK.
  *

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawState.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawState.kt
@@ -1,4 +1,4 @@
-package io.writeopia.sdk.model.story
+package io.writeopia.ui.model
 
 /**
  * The state of document of the TextEditor of Writeopia. This class has all the stories in their

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawStory.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawStory.kt
@@ -1,5 +1,6 @@
 package io.writeopia.ui.model
 
+import io.writeopia.sdk.model.story.Selection
 import io.writeopia.sdk.models.story.StoryStep
 
 /**

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawStory.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/DrawStory.kt
@@ -1,4 +1,4 @@
-package io.writeopia.sdk.model.story
+package io.writeopia.ui.model
 
 import io.writeopia.sdk.models.story.StoryStep
 
@@ -6,7 +6,7 @@ import io.writeopia.sdk.models.story.StoryStep
  * Class meant to be draw in the screen. It contains both the information of a story step and
  * meta information and the state of the TextEditor like if the message is selected
  */
-data class DrawStory(val storyStep: StoryStep, val isSelected: Boolean) {
+data class DrawStory(val storyStep: StoryStep, val cursor: Selection, val isSelected: Boolean) {
 
-    val key = storyStep.key + isSelected.let { if (it) 1 else 0 }
+    val key = storyStep.key + isSelected.let { if (it) 1 else 0 } + cursor.hashCode()
 }

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/Selection.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/Selection.kt
@@ -1,0 +1,13 @@
+package io.writeopia.ui.model
+
+import androidx.compose.ui.text.TextRange
+
+data class Selection(val start: Int, val end: Int) {
+    companion object {
+        fun start(): Selection = Selection(0, 0)
+        fun end(): Selection = Selection(Int.MAX_VALUE, Int.MAX_VALUE)
+        fun fromPosition(position: Int) = Selection(position, position)
+    }
+}
+
+fun Selection.toTextRange() = TextRange(start = start, end = end)

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/TextInput.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/model/TextInput.kt
@@ -1,0 +1,3 @@
+package io.writeopia.ui.model
+
+data class TextInput(val text: String, val start: Int, val end: Int)

--- a/writeopia_ui/src/jsMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
+++ b/writeopia_ui/src/jsMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import io.writeopia.sdk.model.draganddrop.DropInfo
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.components.SwipeBox
 import io.writeopia.ui.draganddrop.target.DragRowTargetWithDragItem

--- a/writeopia_ui/src/jvmMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
+++ b/writeopia_ui/src/jvmMain/kotlin/io/writeopia/ui/drawer/content/TextItemDrawer.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import io.writeopia.sdk.model.draganddrop.DropInfo
-import io.writeopia.sdk.model.draw.DrawInfo
+import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.ui.components.SwipeBox
 import io.writeopia.ui.draganddrop.target.DragRowTargetWithDragItem

--- a/writeopia_ui/src/jvmMain/kotlin/io/writeopia/ui/drawer/factory/DefaultDrawersDesktop.kt
+++ b/writeopia_ui/src/jvmMain/kotlin/io/writeopia/ui/drawer/factory/DefaultDrawersDesktop.kt
@@ -18,7 +18,6 @@ object DefaultDrawersDesktop : DrawersFactory {
         editable: Boolean,
         groupsBackgroundColor: Color,
         onHeaderClick: () -> Unit,
-        textCommandHandler: TextCommandHandler,
     ): Map<Int, StoryStepDrawer> =
         CommonDrawers.create(
             manager,


### PR DESCRIPTION
In this PR:
- Adding bulk delete for desktop app
- Fixing cursor move when pressing arrow keys. Now it follows the current selection.