### PR TITLE
Removing side menu boolean from Ui configuration

### DIFF
--- a/application/common_flows/wide_screen_common/src/commonMain/kotlin/io/writeopia/notes/desktop/components/App.kt
+++ b/application/common_flows/wide_screen_common/src/commonMain/kotlin/io/writeopia/notes/desktop/components/App.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -136,13 +138,11 @@ fun App(
         val globalBackground = WriteopiaTheme.colorScheme.globalBackground
         DraggableScreen {
             Row(Modifier.background(globalBackground)) {
-                val optionsState by globalShellViewModel.showSideMenu.collectAsState()
-                val (showOptions, sideMenuWidth) = optionsState
+                val sideMenuWidth by globalShellViewModel.showSideMenuState.collectAsState()
 
                 SideGlobalMenu(
                     modifier = Modifier.fillMaxHeight(),
                     foldersState = globalShellViewModel.sideMenuItems,
-                    showOptions = showOptions,
                     width = sideMenuWidth.dp,
                     homeClick = {
                         val navType = navigationController.currentBackStackEntry
@@ -229,12 +229,13 @@ fun App(
                                 .draggable(
                                     orientation = Orientation.Horizontal,
                                     state = rememberDraggableState { delta ->
-                                        globalShellViewModel.moveSideMenu(sideMenuWidth + delta / 2)
+                                        globalShellViewModel.moveSideMenu(sideMenuWidth + delta / 1.8F)
                                     },
                                     onDragStopped = {
-                                        globalShellViewModel.saveMenuWidth(sideMenuWidth)
+                                        globalShellViewModel.saveMenuWidth()
                                     },
-                                ),
+                                )
+                                .pointerHoverIcon(PointerIcon.Crosshair),
                         ) {
                             RoundedVerticalDivider(
                                 modifier = Modifier.height(60.dp).align(Alignment.Center),

--- a/application/core/persistence_sqldelight/src/commonMain/kotlin/io/writeopia/sqldelight/theme/UiConfigurationSqlDelightDao.kt
+++ b/application/core/persistence_sqldelight/src/commonMain/kotlin/io/writeopia/sqldelight/theme/UiConfigurationSqlDelightDao.kt
@@ -8,8 +8,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class UiConfigurationSqlDelightDao(database: WriteopiaDb?) {
@@ -25,7 +23,6 @@ class UiConfigurationSqlDelightDao(database: WriteopiaDb?) {
         uiConfiguration.run {
             uiConfigurationQueries?.insert(
                 user_id = user_id,
-                show_side_menu = show_side_menu,
                 color_theme_option = color_theme_option,
                 side_menu_width = side_menu_width
             )

--- a/application/core/persistence_sqldelight/src/commonMain/sqldelight/io/writeopia/app/sql/UiConfigurationEntity.sq
+++ b/application/core/persistence_sqldelight/src/commonMain/sqldelight/io/writeopia/app/sql/UiConfigurationEntity.sq
@@ -1,6 +1,5 @@
 CREATE TABLE uiConfigurationEntity (
   user_id TEXT PRIMARY KEY,
-  show_side_menu INTEGER DEFAULT 0,
   color_theme_option TEXT,
   side_menu_width INTEGER DEFAULT 280
 );
@@ -11,8 +10,8 @@ FROM uiConfigurationEntity
 WHERE uiConfigurationEntity.user_id = ?;
 
 insert:
-INSERT INTO uiConfigurationEntity(user_id, show_side_menu, color_theme_option, side_menu_width)
-VALUES (?, ?, ?, ?)
+INSERT INTO uiConfigurationEntity(user_id, color_theme_option, side_menu_width)
+VALUES (?, ?, ?)
 ON CONFLICT(user_id) DO
-UPDATE SET user_id=excluded.user_id, show_side_menu=excluded.show_side_menu, color_theme_option=excluded.color_theme_option, side_menu_width=excluded.side_menu_width;
+UPDATE SET user_id=excluded.user_id, color_theme_option=excluded.color_theme_option, side_menu_width=excluded.side_menu_width;
 

--- a/application/core/theme/src/androidMain/kotlin/io/writeopia/repository/UiConfigurationRepositoryImpl.kt
+++ b/application/core/theme/src/androidMain/kotlin/io/writeopia/repository/UiConfigurationRepositoryImpl.kt
@@ -18,23 +18,6 @@ class UiConfigurationRepositoryImpl(
     override suspend fun getUiConfigurationEntity(userId: String): UiConfiguration? =
         uiConfigurationDao.getConfigurationByUserId(userId)?.toModel()
 
-    override suspend fun updateShowSideMenu(userId: String, showSideMenu: Boolean) {
-        val entity = getUiConfigurationEntity(userId)
-
-        if (entity != null) {
-            insertUiConfiguration(entity.copy(showSideMenu = showSideMenu))
-        } else {
-            insertUiConfiguration(
-                UiConfiguration(
-                    userId = userId,
-                    showSideMenu = showSideMenu,
-                    colorThemeOption = ColorThemeOption.SYSTEM,
-                    sideMenuWidth = 280F
-                )
-            )
-        }
-    }
-
     override suspend fun updateColorTheme(userId: String, colorThemeOption: ColorThemeOption) {
         val entity = getUiConfigurationEntity(userId)
 
@@ -44,7 +27,6 @@ class UiConfigurationRepositoryImpl(
             insertUiConfiguration(
                 UiConfiguration(
                     userId = userId,
-                    showSideMenu = true,
                     colorThemeOption = colorThemeOption,
                     sideMenuWidth = 280F
                 )

--- a/application/core/theme/src/androidMain/kotlin/io/writeopia/repository/extensions/UiConfigurationRoomExtensions.kt
+++ b/application/core/theme/src/androidMain/kotlin/io/writeopia/repository/extensions/UiConfigurationRoomExtensions.kt
@@ -11,7 +11,6 @@ fun UiConfiguration.toRoomEntity() = UiConfigurationEntity(
 
 fun UiConfigurationEntity.toModel() = UiConfiguration(
     userId = userId,
-    showSideMenu = false,
     colorThemeOption = ColorThemeOption.fromText(colorThemeOption) ?: ColorThemeOption.SYSTEM,
     sideMenuWidth = 280F
 )

--- a/application/core/theme/src/commonMain/kotlin/io/writeopia/extensions/UiConfigurationExtensions.kt
+++ b/application/core/theme/src/commonMain/kotlin/io/writeopia/extensions/UiConfigurationExtensions.kt
@@ -6,14 +6,12 @@ import io.writeopia.model.UiConfiguration
 
 fun UiConfiguration.toEntity() = UiConfigurationEntity(
     user_id = userId,
-    show_side_menu = showSideMenu.toLong(),
     color_theme_option = colorThemeOption.theme,
     side_menu_width = sideMenuWidth.toLong()
 )
 
 fun UiConfigurationEntity.toModel() = UiConfiguration(
     userId = user_id,
-    showSideMenu = show_side_menu.toBoolean(),
     colorThemeOption = ColorThemeOption.fromText(color_theme_option) ?: ColorThemeOption.SYSTEM,
     sideMenuWidth = side_menu_width?.toFloat() ?: 280F
 )

--- a/application/core/theme/src/commonMain/kotlin/io/writeopia/model/UiConfiguration.kt
+++ b/application/core/theme/src/commonMain/kotlin/io/writeopia/model/UiConfiguration.kt
@@ -2,7 +2,6 @@ package io.writeopia.model
 
 data class UiConfiguration(
     val userId: String,
-    val showSideMenu: Boolean,
     val colorThemeOption: ColorThemeOption,
     val sideMenuWidth: Float
 )

--- a/application/core/theme/src/commonMain/kotlin/io/writeopia/repository/UiConfigurationMemoryRepository.kt
+++ b/application/core/theme/src/commonMain/kotlin/io/writeopia/repository/UiConfigurationMemoryRepository.kt
@@ -10,7 +10,6 @@ class UiConfigurationMemoryRepository : UiConfigurationRepository {
     private var uiConfiguration = MutableStateFlow(
         UiConfiguration(
             userId = "userId",
-            showSideMenu = true,
             colorThemeOption = ColorThemeOption.SYSTEM,
             sideMenuWidth = 280F
         )
@@ -22,10 +21,6 @@ class UiConfigurationMemoryRepository : UiConfigurationRepository {
 
     override suspend fun getUiConfigurationEntity(userId: String): UiConfiguration =
         uiConfiguration.value
-
-    override suspend fun updateShowSideMenu(userId: String, showSideMenu: Boolean) {
-        uiConfiguration.value = uiConfiguration.value.copy(showSideMenu = showSideMenu)
-    }
 
     override suspend fun updateColorTheme(userId: String, colorThemeOption: ColorThemeOption) {
         uiConfiguration.value = uiConfiguration.value.copy(colorThemeOption = colorThemeOption)

--- a/application/core/theme/src/commonMain/kotlin/io/writeopia/repository/UiConfigurationRepository.kt
+++ b/application/core/theme/src/commonMain/kotlin/io/writeopia/repository/UiConfigurationRepository.kt
@@ -10,8 +10,6 @@ interface UiConfigurationRepository {
 
     suspend fun getUiConfigurationEntity(userId: String): UiConfiguration?
 
-    suspend fun updateShowSideMenu(userId: String, showSideMenu: Boolean)
-
     suspend fun updateColorTheme(userId: String, colorThemeOption: ColorThemeOption)
 
     fun listenForUiConfiguration(

--- a/application/core/theme/src/commonMain/kotlin/io/writeopia/repository/UiConfigurationSqlDelightRepository.kt
+++ b/application/core/theme/src/commonMain/kotlin/io/writeopia/repository/UiConfigurationSqlDelightRepository.kt
@@ -20,23 +20,6 @@ class UiConfigurationSqlDelightRepository internal constructor(
     override suspend fun getUiConfigurationEntity(userId: String): UiConfiguration? =
         uiConfigurationDao.getConfigurationByUserId(userId)?.toModel()
 
-    override suspend fun updateShowSideMenu(userId: String, showSideMenu: Boolean) {
-        val entity = getUiConfigurationEntity(userId)
-
-        if (entity != null) {
-            insertUiConfiguration(entity.copy(showSideMenu = showSideMenu))
-        } else {
-            insertUiConfiguration(
-                UiConfiguration(
-                    userId = userId,
-                    showSideMenu = showSideMenu,
-                    colorThemeOption = ColorThemeOption.SYSTEM,
-                    sideMenuWidth = 280F
-                )
-            )
-        }
-    }
-
     override suspend fun updateColorTheme(userId: String, colorThemeOption: ColorThemeOption) {
         val entity = getUiConfigurationEntity(userId)
 
@@ -46,7 +29,6 @@ class UiConfigurationSqlDelightRepository internal constructor(
             insertUiConfiguration(
                 UiConfiguration(
                     userId = userId,
-                    showSideMenu = true,
                     colorThemeOption = colorThemeOption,
                     sideMenuWidth = 280F
                 )

--- a/application/core/theme/src/commonTest/kotlin/io/writeopia/repository/UiConfigurationRepositoryCommonTest.kt
+++ b/application/core/theme/src/commonTest/kotlin/io/writeopia/repository/UiConfigurationRepositoryCommonTest.kt
@@ -1,8 +1,8 @@
 package io.writeopia.repository
 
 import io.writeopia.model.ColorThemeOption
+import io.writeopia.model.UiConfiguration
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 object UiConfigurationRepositoryCommonTest {
 
@@ -20,11 +20,13 @@ object UiConfigurationRepositoryCommonTest {
         }
     }
 
-    suspend fun shouldBePossibleToKeepChoiceToHideSideMenu(repository: UiConfigurationRepository) {
+    suspend fun shouldBePossibleToKeepChoiceToMoveSideMenu(repository: UiConfigurationRepository) {
         val userId = "disconnected_user"
+        val width = 200F
+
         repository.run {
-            updateShowSideMenu(userId, true)
-            assertTrue(getUiConfigurationEntity(userId)?.showSideMenu == true)
+            insertUiConfiguration(UiConfiguration(userId, ColorThemeOption.SYSTEM, width))
+            assertEquals(getUiConfigurationEntity(userId)?.sideMenuWidth, width)
         }
     }
 }

--- a/application/core/theme/src/jvmTest/kotlin/io/writeopia/repository/UiConfigurationSqlDelightRepositoryTest.kt
+++ b/application/core/theme/src/jvmTest/kotlin/io/writeopia/repository/UiConfigurationSqlDelightRepositoryTest.kt
@@ -14,8 +14,8 @@ class UiConfigurationSqlDelightRepositoryTest {
     }
 
     @Test
-    fun shouldBePossibleToKeepChoiceToHideSideMenu() = runTest {
-        UiConfigurationRepositoryCommonTest.shouldBePossibleToKeepChoiceToHideSideMenu(
+    fun shouldBePossibleToKeepChoiceToMoveSideMenu() = runTest {
+        UiConfigurationRepositoryCommonTest.shouldBePossibleToKeepChoiceToMoveSideMenu(
             getRepository()
         )
     }

--- a/application/desktopApp/src/jvmMain/kotlin/io/writeopia/desktop/MainDesktop.kt
+++ b/application/desktopApp/src/jvmMain/kotlin/io/writeopia/desktop/MainDesktop.kt
@@ -35,7 +35,7 @@ import java.io.File
 import androidx.compose.ui.input.key.KeyEvent as AndroidKeyEvent
 
 private const val APP_DIRECTORY = ".writeopia"
-private const val DB_VERSION = 3
+private const val DB_VERSION = 4
 
 fun main() = application {
     val coroutineScope = rememberCoroutineScope()

--- a/application/features/global_shell/config/ktlint/baseline.xml
+++ b/application/features/global_shell/config/ktlint/baseline.xml
@@ -49,6 +49,6 @@
         <error line="50" column="17" source="standard:class-naming" />
     </file>
     <file name="src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt">
-        <error line="55" column="17" source="standard:property-naming" />
+        <error line="56" column="17" source="standard:property-naming" />
     </file>
 </baseline>

--- a/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/SideGlobalMenu.kt
+++ b/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/SideGlobalMenu.kt
@@ -65,7 +65,6 @@ fun SideGlobalMenu(
     modifier: Modifier = Modifier,
     foldersState: StateFlow<List<MenuItemUi>>,
     background: Color = WriteopiaTheme.colorScheme.globalBackground,
-    showOptions: Boolean,
     width: Dp = FINAL_WIDTH.dp,
     homeClick: () -> Unit,
     favoritesClick: () -> Unit,
@@ -78,9 +77,7 @@ fun SideGlobalMenu(
     moveRequest: (MenuItemUi, String) -> Unit,
     expandFolder: (String) -> Unit
 ) {
-    val widthState by derivedStateOf {
-        if (showOptions) width else 0.dp
-    }
+    val widthState by derivedStateOf { width }
 
     val widthAnimatedState by animateDpAsState(widthState)
     val showContent by derivedStateOf {
@@ -440,7 +437,6 @@ fun SideGlobalMenuPreview() {
     SideGlobalMenu(
         modifier = Modifier.background(Color.Cyan),
         foldersState = MutableStateFlow(emptyList()),
-        showOptions = true,
         homeClick = {},
         favoritesClick = {},
         settingsClick = {},

--- a/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt
+++ b/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt
@@ -1,5 +1,6 @@
 package io.writeopia.global.shell.viewmodel
 
+import androidx.compose.ui.unit.dp
 import io.writeopia.auth.core.manager.AuthManager
 import io.writeopia.common.utils.KmpViewModel
 import io.writeopia.common.utils.collections.reverseTraverse
@@ -77,14 +78,13 @@ class GlobalShellKmpViewModel(
         }.stateIn(coroutineScope, SharingStarted.Lazily, null)
     }
 
-    override val showSideMenu: StateFlow<Pair<Boolean, Float>> by lazy {
+    override val showSideMenuState: StateFlow<Float> by lazy {
         combine(
             uiConfigurationRepo.listenForUiConfiguration(::getUserId, coroutineScope)
                 .filterNotNull(),
             sideMenuWidthState.asStateFlow()
-        ) { configuration, width ->
-            configuration.showSideMenu to (width ?: configuration.sideMenuWidth)
-        }.stateIn(coroutineScope, SharingStarted.Lazily, false to 280F)
+        ) { configuration, width -> width ?: configuration.sideMenuWidth.also { println("configuration.sideMenuWidth: $it") }
+        }.stateIn(coroutineScope, SharingStarted.Lazily, 280F)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -158,7 +158,28 @@ class GlobalShellKmpViewModel(
     }
 
     override fun toggleSideMenu() {
-        setShowSideMenu(!showSideMenu.value.first)
+        val width = sideMenuWidthState.value
+
+        sideMenuWidthState.value = if ((width ?: 0F).dp < 5.dp) 280F else 0F
+        saveMenuWidth()
+    }
+
+    override fun saveMenuWidth() {
+        val width = sideMenuWidthState.value ?: 280F
+
+        coroutineScope.launch(Dispatchers.Default) {
+            val uiConfiguration = uiConfigurationRepo.getUiConfigurationEntity("disconnected_user")
+                ?: UiConfiguration(
+                    userId = "disconnected_user",
+                    colorThemeOption = ColorThemeOption.SYSTEM,
+                    sideMenuWidth = width
+                )
+            uiConfigurationRepo.insertUiConfiguration(uiConfiguration.copy(sideMenuWidth = width).also { println("width: $width") })
+        }
+    }
+
+    override fun moveSideMenu(width: Float) {
+        sideMenuWidthState.value = width
     }
 
     override fun showSettings() {
@@ -169,31 +190,8 @@ class GlobalShellKmpViewModel(
         _showSettingsState.value = false
     }
 
-    override fun saveMenuWidth(width: Float) {
-        coroutineScope.launch(Dispatchers.Default) {
-            val uiConfiguration = uiConfigurationRepo.getUiConfigurationEntity("disconnected_user")
-                ?: UiConfiguration(
-                    userId = "disconnected_user",
-                    showSideMenu = true,
-                    colorThemeOption = ColorThemeOption.SYSTEM,
-                    sideMenuWidth = 280F
-                )
-            uiConfigurationRepo.insertUiConfiguration(uiConfiguration.copy(sideMenuWidth = width))
-        }
-    }
-
-    override fun moveSideMenu(width: Float) {
-        sideMenuWidthState.value = width
-    }
-
     private suspend fun getUserId(): String =
         localUserId ?: authManager.getUser().id.also { id ->
             localUserId = id
         }
-
-    private fun setShowSideMenu(enabled: Boolean) {
-        coroutineScope.launch(Dispatchers.Default) {
-            uiConfigurationRepo.updateShowSideMenu(userId = getUserId(), showSideMenu = enabled)
-        }
-    }
 }

--- a/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt
+++ b/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt
@@ -83,7 +83,8 @@ class GlobalShellKmpViewModel(
             uiConfigurationRepo.listenForUiConfiguration(::getUserId, coroutineScope)
                 .filterNotNull(),
             sideMenuWidthState.asStateFlow()
-        ) { configuration, width -> width ?: configuration.sideMenuWidth.also { println("configuration.sideMenuWidth: $it") }
+        ) { configuration, width ->
+            width ?: configuration.sideMenuWidth
         }.stateIn(coroutineScope, SharingStarted.Lazily, 280F)
     }
 
@@ -168,13 +169,14 @@ class GlobalShellKmpViewModel(
         val width = sideMenuWidthState.value ?: 280F
 
         coroutineScope.launch(Dispatchers.Default) {
-            val uiConfiguration = uiConfigurationRepo.getUiConfigurationEntity("disconnected_user")
-                ?: UiConfiguration(
-                    userId = "disconnected_user",
-                    colorThemeOption = ColorThemeOption.SYSTEM,
-                    sideMenuWidth = width
-                )
-            uiConfigurationRepo.insertUiConfiguration(uiConfiguration.copy(sideMenuWidth = width).also { println("width: $width") })
+            val uiConfiguration =
+                uiConfigurationRepo.getUiConfigurationEntity("disconnected_user")
+                    ?: UiConfiguration(
+                        userId = "disconnected_user",
+                        colorThemeOption = ColorThemeOption.SYSTEM,
+                        sideMenuWidth = width
+                    )
+            uiConfigurationRepo.insertUiConfiguration(uiConfiguration.copy(sideMenuWidth = width))
         }
     }
 

--- a/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellViewModel.kt
+++ b/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface GlobalShellViewModel : FolderController {
     val sideMenuItems: StateFlow<List<MenuItemUi>>
-    val showSideMenu: StateFlow<Pair<Boolean, Float>>
+    val showSideMenuState: StateFlow<Float>
     val highlightItem: StateFlow<String?>
     val menuItemsPerFolderId: StateFlow<Map<String, List<MenuItem>>>
     val editFolderState: StateFlow<Folder?>
@@ -23,7 +23,7 @@ interface GlobalShellViewModel : FolderController {
 
     fun hideSettings()
 
-    fun saveMenuWidth(width: Float)
+    fun saveMenuWidth()
 
     fun moveSideMenu(width: Float)
 }


### PR DESCRIPTION
In this PR:
- Removing code to persist information about showing side menu as a boolean, now it only keeps the width. The toggle button sets the width either to a default value or 0. 
- Allowing drag from position 0 in the side menu.