### PR TITLE
feat(UI): Resize documents cards for each platform

### DIFF
--- a/application/features/note_menu/src/androidMain/kotlin/io/writeopia/notemenu/utils/UiUtils.android.kt
+++ b/application/features/note_menu/src/androidMain/kotlin/io/writeopia/notemenu/utils/UiUtils.android.kt
@@ -1,0 +1,6 @@
+package io.writeopia.notemenu.utils
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+actual fun minimalNoteCardWidth(): Dp = MOBILE_NOTE_WIDTH.dp

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/data/usecase/NotesUseCase.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/data/usecase/NotesUseCase.kt
@@ -6,7 +6,7 @@ import io.writeopia.notemenu.data.model.NotesNavigation
 import io.writeopia.notemenu.data.repository.ConfigurationRepository
 import io.writeopia.notemenu.data.repository.FolderRepository
 import io.writeopia.notemenu.ui.dto.MenuItemUi
-import io.writeopia.notemenu.utils.sortedWithOrderBy
+import io.writeopia.notemenu.extensions.sortedWithOrderBy
 import io.writeopia.sdk.models.document.Document
 import io.writeopia.sdk.models.document.MenuItem
 import io.writeopia.sdk.models.id.GenerateId

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/extensions/ListExtensions.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/extensions/ListExtensions.kt
@@ -1,4 +1,4 @@
-package io.writeopia.notemenu.utils
+package io.writeopia.notemenu.extensions
 
 import io.writeopia.sdk.models.document.MenuItem
 import io.writeopia.sdk.persistence.core.sorting.OrderBy

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/ui/screen/documents/NoteItems.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/ui/screen/documents/NoteItems.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.writeopia.common.utils.IconChange
 import io.writeopia.common.utils.ResultData
@@ -51,6 +52,7 @@ import io.writeopia.commonui.IconsPicker
 import io.writeopia.notemenu.data.model.NotesArrangement
 import io.writeopia.notemenu.ui.dto.MenuItemUi
 import io.writeopia.notemenu.ui.dto.NotesUi
+import io.writeopia.notemenu.utils.minimalNoteCardWidth
 import io.writeopia.sdk.model.draganddrop.DropInfo
 import io.writeopia.sdk.models.story.StoryStep
 import io.writeopia.sdk.models.story.StoryTypes
@@ -72,6 +74,7 @@ const val ADD_NOTE_TEST_TAG = "addNote"
 @Composable
 fun NotesCards(
     documents: ResultData<NotesUi>,
+    minimalNoteWidth: Dp = minimalNoteCardWidth(),
     loadNote: (String, String) -> Unit,
     selectionListener: (String, Boolean) -> Unit,
     folderClick: (String) -> Unit,
@@ -95,6 +98,7 @@ fun NotesCards(
                         NotesArrangement.STAGGERED_GRID -> {
                             LazyStaggeredGridNotes(
                                 documentsUiList,
+                                minimalNoteWidth = minimalNoteWidth,
                                 selectionListener = selectionListener,
                                 onDocumentClick = loadNote,
                                 folderClick = folderClick,
@@ -107,6 +111,7 @@ fun NotesCards(
                         NotesArrangement.GRID -> {
                             LazyGridNotes(
                                 documentsUiList,
+                                minimalNoteWidth = minimalNoteWidth,
                                 selectionListener = selectionListener,
                                 onDocumentClick = loadNote,
                                 folderClick = folderClick,
@@ -158,6 +163,7 @@ fun NotesCards(
 @Composable
 private fun LazyStaggeredGridNotes(
     documents: List<MenuItemUi>,
+    minimalNoteWidth: Dp,
     onDocumentClick: (String, String) -> Unit,
     selectionListener: (String, Boolean) -> Unit,
     moveRequest: (MenuItemUi, String) -> Unit,
@@ -170,7 +176,7 @@ private fun LazyStaggeredGridNotes(
 
     LazyVerticalStaggeredGrid(
         modifier = modifier,
-        columns = StaggeredGridCells.Adaptive(minSize = 150.dp),
+        columns = StaggeredGridCells.Adaptive(minSize = minimalNoteWidth),
         horizontalArrangement = Arrangement.spacedBy(spacing),
         verticalItemSpacing = spacing,
         contentPadding = contentPadding,
@@ -216,6 +222,7 @@ private fun LazyStaggeredGridNotes(
 @Composable
 private fun LazyGridNotes(
     documents: List<MenuItemUi>,
+    minimalNoteWidth: Dp,
     onDocumentClick: (String, String) -> Unit,
     folderClick: (String) -> Unit,
     moveRequest: (MenuItemUi, String) -> Unit,
@@ -228,7 +235,7 @@ private fun LazyGridNotes(
 
     LazyVerticalGrid(
         modifier = modifier,
-        columns = GridCells.Adaptive(minSize = 150.dp),
+        columns = GridCells.Adaptive(minSize = minimalNoteWidth),
         horizontalArrangement = spacing,
         verticalArrangement = spacing,
         contentPadding = contentPadding,

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/utils/UiUtils.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/utils/UiUtils.kt
@@ -6,4 +6,3 @@ expect fun minimalNoteCardWidth(): Dp
 
 const val DESKTOP_NOTE_WIDTH = 220
 const val MOBILE_NOTE_WIDTH = 150
-

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/utils/UiUtils.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/utils/UiUtils.kt
@@ -1,0 +1,9 @@
+package io.writeopia.notemenu.utils
+
+import androidx.compose.ui.unit.Dp
+
+expect fun minimalNoteCardWidth(): Dp
+
+const val DESKTOP_NOTE_WIDTH = 220
+const val MOBILE_NOTE_WIDTH = 150
+

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/ChooseNoteKmpViewModel.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/ChooseNoteKmpViewModel.kt
@@ -128,7 +128,7 @@ internal class ChooseNoteKmpViewModel(
             val previewLimit = when (arrangement) {
                 NotesArrangement.LIST -> 4
                 NotesArrangement.GRID -> 4
-                NotesArrangement.STAGGERED_GRID -> 10
+                NotesArrangement.STAGGERED_GRID -> 6
             }
 
             resultData.map { documentList ->

--- a/application/features/note_menu/src/jsMain/kotlin/io/writeopia/notemenu/utils/UiUtils.js.kt
+++ b/application/features/note_menu/src/jsMain/kotlin/io/writeopia/notemenu/utils/UiUtils.js.kt
@@ -1,0 +1,6 @@
+package io.writeopia.notemenu.utils
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+actual fun minimalNoteCardWidth(): Dp = DESKTOP_NOTE_WIDTH.dp

--- a/application/features/note_menu/src/jvmMain/kotlin/io/writeopia/notemenu/utils/UiUtils.jvm.kt
+++ b/application/features/note_menu/src/jvmMain/kotlin/io/writeopia/notemenu/utils/UiUtils.jvm.kt
@@ -1,0 +1,6 @@
+package io.writeopia.notemenu.utils
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+actual fun minimalNoteCardWidth(): Dp = DESKTOP_NOTE_WIDTH.dp

--- a/application/features/note_menu/src/nativeMain/kotlin/io/writeopia/notemenu/utils/UiUtils.native.kt
+++ b/application/features/note_menu/src/nativeMain/kotlin/io/writeopia/notemenu/utils/UiUtils.native.kt
@@ -1,0 +1,6 @@
+package io.writeopia.notemenu.utils
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+actual fun minimalNoteCardWidth(): Dp = MOBILE_NOTE_WIDTH.dp

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/HeaderPreviewDrawer.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/drawer/preview/HeaderPreviewDrawer.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.writeopia.ui.model.DrawInfo
 import io.writeopia.sdk.models.story.StoryStep
@@ -87,7 +88,8 @@ class HeaderPreviewDrawer(
                     text = step.text ?: "",
                     style = style ?: MaterialTheme.typography.titleLarge,
                     color = textColor,
-                    maxLines = 1
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }


### PR DESCRIPTION
Now each platform will have a different minimal width for the cards of documents in the menu. 