### PR TITLE
feat: Not allowing cyclical folders

### DIFF
--- a/application/core/utils/src/commonMain/kotlin/io/writeopia/common/utils/Node.kt
+++ b/application/core/utils/src/commonMain/kotlin/io/writeopia/common/utils/Node.kt
@@ -6,11 +6,30 @@ interface Node {
 
     fun addNotes(nodes: List<Node>)
 
+    /**
+     * Get the next notes. Only the next notes, not the whole graph
+     */
     fun getNodes(): List<Node>
 
+    /**
+     * Get all notes as list. Expands all nodes.
+     */
     fun toList(): List<Node> =
         listOf(this) + this.getNodes().flatMap { internalNodes -> internalNodes.toList() }
+
+    companion object {
+        fun <T : Node> anyNode(node: T, predicate: (T) -> Boolean): Boolean {
+            val match = predicate(node)
+
+            return match || node.getNodes()
+                .map { it as T }
+                .any { innerNode -> anyNode(innerNode, predicate) }
+        }
+    }
 }
+
+fun <T : Node> T.anyNode(predicate: (T) -> Boolean): Boolean =
+    Node.anyNode(this, predicate)
 
 /**
  * Creates a node tree of Node<T>. The head of the tree should be provided.

--- a/application/core/utils/src/commonMain/kotlin/io/writeopia/common/utils/collections/MapExtensions.kt
+++ b/application/core/utils/src/commonMain/kotlin/io/writeopia/common/utils/collections/MapExtensions.kt
@@ -16,7 +16,11 @@ fun <T : Node> Map<String, List<T>>.toNodeTree(
     filterPredicate: (T) -> Boolean = { true }
 ): Node = createNodeTree(this, node, filterPredicate = filterPredicate)
 
-inline fun <reified T : Traversable, U> List<T>.reverseTraverse(
+/**
+ * Traverses an traversable iterable, filters the nodes and map the items of the traversal
+ * with mapFunc
+ */
+inline fun <reified T : Traversable, U> Iterable<T>.traverse(
     initialId: String,
     targetId: String = "root",
     noinline filterPredicate: ((T) -> Boolean)? = null,

--- a/application/core/utils/src/commonTest/kotlin/io/writeopia/common/utils/NodeTests.kt
+++ b/application/core/utils/src/commonTest/kotlin/io/writeopia/common/utils/NodeTests.kt
@@ -1,0 +1,81 @@
+package io.writeopia.common.utils
+
+import io.writeopia.common.utils.collections.SimpleNode
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NodeTests {
+
+    @Test
+    fun isShouldBePossibleToFindInNodeTree() {
+        val nodeTree = SimpleNode(
+            id = "root",
+            simpleNodes = mutableListOf(
+                SimpleNode(
+                    id = "0",
+                    depth = 0,
+                    simpleNodes = mutableListOf(
+                        SimpleNode(
+                            id = "3",
+                            depth = 1,
+                            simpleNodes = mutableListOf()
+                        ),
+                        SimpleNode(
+                            id = "4",
+                            depth = 1,
+                            simpleNodes = mutableListOf(
+                                SimpleNode(id = "5", depth = 2, simpleNodes = mutableListOf()),
+                                SimpleNode(id = "6", depth = 2, simpleNodes = mutableListOf()),
+                            )
+                        ),
+                    )
+                ),
+                SimpleNode(id = "1", depth = 0, simpleNodes = mutableListOf()),
+                SimpleNode(id = "2", depth = 0, simpleNodes = mutableListOf()),
+            )
+        )
+
+        val result = nodeTree.anyNode { simpleNode ->
+            simpleNode.id == "6"
+        }
+
+        assertTrue { result }
+    }
+
+    @Test
+    fun whenNoResultsWereFoundItShouldReturnFalse() {
+        val nodeTree = SimpleNode(
+            id = "root",
+            simpleNodes = mutableListOf(
+                SimpleNode(
+                    id = "0",
+                    depth = 0,
+                    simpleNodes = mutableListOf(
+                        SimpleNode(
+                            id = "3",
+                            depth = 1,
+                            simpleNodes = mutableListOf()
+                        ),
+                        SimpleNode(
+                            id = "4",
+                            depth = 1,
+                            simpleNodes = mutableListOf(
+                                SimpleNode(id = "5", depth = 2, simpleNodes = mutableListOf()),
+                                SimpleNode(id = "6", depth = 2, simpleNodes = mutableListOf()),
+                            )
+                        ),
+                    )
+                ),
+                SimpleNode(id = "1", depth = 0, simpleNodes = mutableListOf()),
+                SimpleNode(id = "2", depth = 0, simpleNodes = mutableListOf()),
+            )
+        )
+
+        val result = nodeTree.anyNode { simpleNode ->
+            simpleNode.id == "you won't find this id!!"
+        }
+
+        assertFalse { result }
+    }
+}

--- a/application/core/utils/src/commonTest/kotlin/io/writeopia/common/utils/collections/MapExtensionsKtTest.kt
+++ b/application/core/utils/src/commonTest/kotlin/io/writeopia/common/utils/collections/MapExtensionsKtTest.kt
@@ -1,8 +1,6 @@
-package io.writeopia.common.tests.collections
+package io.writeopia.common.utils.collections
 
 import io.writeopia.common.utils.Node
-import io.writeopia.common.utils.collections.merge
-import io.writeopia.common.utils.collections.toNodeTree
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt
+++ b/application/features/global_shell/src/commonMain/kotlin/io/writeopia/global/shell/viewmodel/GlobalShellKmpViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import io.writeopia.auth.core.manager.AuthManager
 import io.writeopia.common.utils.DISCONNECTED_USER_ID
 import io.writeopia.common.utils.IconChange
-import io.writeopia.common.utils.collections.reverseTraverse
+import io.writeopia.common.utils.collections.traverse
 import io.writeopia.common.utils.collections.toNodeTree
 import io.writeopia.common.utils.persistence.configuration.WorkspaceConfigRepository
 import io.writeopia.model.ColorThemeOption
@@ -145,7 +145,7 @@ class GlobalShellKmpViewModel(
             notesNavigationUseCase.navigationState
         ) { perFolder, navigation ->
             val menuItems = perFolder.values.flatten().map { it.toUiCard() }
-            listOf("Home") + menuItems.reverseTraverse(
+            listOf("Home") + menuItems.traverse(
                 navigation.id,
                 filterPredicate = { item -> item is MenuItemUi.FolderUi },
                 mapFunc = { item -> item.title }

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/FolderStateController.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/FolderStateController.kt
@@ -2,6 +2,7 @@ package io.writeopia.notemenu.viewmodel
 
 import io.writeopia.auth.core.manager.AuthManager
 import io.writeopia.common.utils.IconChange
+import io.writeopia.common.utils.anyNode
 import io.writeopia.models.Folder
 import io.writeopia.notemenu.data.usecase.NotesUseCase
 import io.writeopia.notemenu.ui.dto.MenuItemUi
@@ -58,6 +59,13 @@ class FolderStateController(
     override fun moveToFolder(menuItemUi: MenuItemUi, parentId: String) {
         if (menuItemUi.documentId != parentId) {
             coroutineScope.launch(Dispatchers.Default) {
+                // Avoid cyclical graphs
+                if (menuItemUi is MenuItemUi.FolderUi &&
+                    menuItemUi.anyNode { node -> node.id == parentId }
+                ) {
+                    return@launch
+                }
+
                 notesUseCase.moveItem(menuItemUi, parentId)
             }
         }


### PR DESCRIPTION
Now allowing users to create a cyclical folders. FolderA -> FolderB and FolderB -> FolderA is not allowed